### PR TITLE
routing: URL matcher example

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import { Routes, RouterModule, UrlSegment } from '@angular/router';
 import { HomeComponent } from './home/home.component';
 import { DocumentComponent } from './record/document/document.component';
 import { InstitutionComponent } from './record/institution/institution.component';
@@ -36,10 +36,72 @@ const canDelete = (record) => {
   return true;
 };
 
+export function matchedUrl(url: UrlSegment[]) {
+  const segments = [
+    new UrlSegment(url[0].path, {}),
+    new UrlSegment(url[1].path, {})
+  ];
+
+  return {
+    consumed: segments,
+    posParams: { type: new UrlSegment(url[1].path, {}) }
+  };
+}
+
 const routes: Routes = [
   {
     path: '',
     component: HomeComponent
+  },
+  {
+    matcher: (url) => {
+      if (url[0].path === 'records' && url[1].path === 'documents') {
+        return matchedUrl(url);
+      }
+      return null;
+    },
+    children: [
+      { path: '', component: RecordSearchComponent },
+      { path: 'detail/:pid', component: RecordDetailComponent }
+    ],
+    data: {
+      showSearchInput: true,
+      adminMode: false,
+      linkPrefix: 'records',
+      types: [
+        {
+          key: 'documents',
+          label: 'Documents',
+          component: DocumentComponent,
+          preFilters: {
+            institution: 'usi'
+          }
+        }
+      ]
+    }
+  },
+  {
+    matcher: (url) => {
+      if (url[0].path === 'records' && url[1].path === 'institutions') {
+        return matchedUrl(url);
+      }
+      return null;
+    },
+    children: [
+      { path: '', component: RecordSearchComponent },
+      { path: 'detail/:pid', component: RecordDetailComponent }
+    ],
+    data: {
+      showSearchInput: true,
+      adminMode: false,
+      linkPrefix: 'records',
+      types: [
+        {
+          key: 'institutions',
+          label: 'Institutions'
+        }
+      ]
+    }
   },
   {
     path: 'usi/record/search',

--- a/projects/ng-core-tester/src/app/app.component.html
+++ b/projects/ng-core-tester/src/app/app.component.html
@@ -28,7 +28,6 @@
     </div>
   </div>
 </nav>
-<ng-core-alert timeout="5000"></ng-core-alert>
 
 <div class="container my-5">
   <router-outlet></router-outlet>

--- a/projects/ng-core-tester/src/app/app.component.ts
+++ b/projects/ng-core-tester/src/app/app.component.ts
@@ -14,10 +14,9 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { CoreConfigService } from '@rero/ng-core';
-import { Config, AlertService } from '@rero/ng-core';
 
 
 @Component({
@@ -40,21 +39,36 @@ export class AppComponent implements OnInit {
         iconCssClass: 'fa fa-home'
       },
       {
-        name: 'Global records',
-        routerLink: '/record/search/documents',
-        iconCssClass: 'fa fa-book'
-      },
-      {
-        name: 'USI records',
-        routerLink: '/usi/record/search/documents'
-      },
-      {
-        name: 'HEVS records',
-        routerLink: '/hevs/record/search/documents'
-      },
-      {
-        name: 'Backend records',
-        routerLink: '/admin/record/search/documents'
+        name: 'Records',
+        href: '#',
+        cssActiveClass: '',
+        entries: [
+          {
+            name: 'Global records',
+            routerLink: '/record/search/documents',
+            iconCssClass: 'fa fa-book'
+          },
+          {
+            name: 'USI records',
+            routerLink: '/usi/record/search/documents'
+          },
+          {
+            name: 'HEVS records',
+            routerLink: '/hevs/record/search/documents'
+          },
+          {
+            name: 'Backend records',
+            routerLink: '/admin/record/search/documents'
+          },
+          {
+            name: 'Document records',
+            routerLink: '/records/documents'
+          },
+          {
+            name: 'Organizations records',
+            routerLink: '/records/institutions'
+          }
+        ]
       }
     ]
   };


### PR DESCRIPTION
* Provides an example for how to use URLs matchers.
* Removes references to AlertComponent.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>