### PR TITLE
search: fix total counters

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -207,7 +207,7 @@ export class RecordSearchComponent implements OnInit {
     this.getRecords(this.inRouting === false);
 
     for (const type of this.types) {
-      this.recordService.getRecords(type.key, '', 1, 0, [], this.config.preFilters || {}).subscribe(records => {
+      this.recordService.getRecords(type.key, '', 1, 1, [], this.config.preFilters || {}).subscribe(records => {
         type.total = records.hits.total;
       });
     }


### PR DESCRIPTION
* Gets 1 record in API calls because 0 doesn't work after Invenio upgrade to 3.2.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>