### PR TITLE
api: get $ref endpoint

### DIFF
--- a/projects/rero/ng-core/src/lib/api/api.service.ts
+++ b/projects/rero/ng-core/src/lib/api/api.service.ts
@@ -63,4 +63,13 @@ export class ApiService {
 
     return endpoint;
   }
+
+  /**
+   * Returne $ref endpoint to resource
+   * @param type - string, type of resource
+   * @param id - string id of the record
+   */
+  getRefEndpoint(type: string, id: string) {
+    return `${this.configService.$refPrefix}${this.endpointPrefix}/${type}/${id}`;
+  }
 }


### PR DESCRIPTION
* Adds a method to get $ref endpoint for a given resource.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>