### PR TITLE
records: add link to detail on brief view title

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -16,7 +16,7 @@
  */
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule, UrlSegment } from '@angular/router';
-import { of } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { HomeComponent } from './home/home.component';
 import { DocumentComponent } from './record/document/document.component';
@@ -39,6 +39,10 @@ const canDelete = (record) => {
     can: Math.random() >= 0.5,
     message: `You <strong>cannot</strong> delete this record #${record.id} !`
   });
+};
+
+const canRead = (record: any): Observable<boolean> => {
+  return of(Math.random() >= 0.5);
 };
 
 const aggregations = (agg: object) => {
@@ -132,7 +136,7 @@ const routes: Routes = [
           }
         },
         {
-          key: 'patrons',
+          key: 'users',
           label: 'Utilisateurs'
         }
       ]
@@ -198,6 +202,7 @@ const routes: Routes = [
           canAdd,
           canUpdate,
           canDelete,
+          canRead,
           aggregations
         },
         {
@@ -206,7 +211,7 @@ const routes: Routes = [
           component: InstitutionComponent
         },
         {
-          key: 'patrons',
+          key: 'users',
           label: 'Utilisateurs'
         }
       ]

--- a/projects/ng-core-tester/src/app/record/document/detail/detail.component.html
+++ b/projects/ng-core-tester/src/app/record/document/detail/detail.component.html
@@ -2,6 +2,6 @@
 <p>
     <span class="badge badge-primary mr-1" *ngFor="let author of record.metadata.authors">{{ author.name }}</span>
 </p>
-<div class="text-justify">
+<div class="text-justify" *ngIf="record.metadata.abstracts">
     {{ record.metadata.abstracts[0].value }}
 </div>

--- a/projects/ng-core-tester/src/app/record/document/document.component.html
+++ b/projects/ng-core-tester/src/app/record/document/document.component.html
@@ -1,4 +1,9 @@
-<h5>{{ record.metadata.title }}</h5>
+<h5>
+    <a href [routerLink]="detailUrl" *ngIf="detailUrl; else titleWithoutLink">{{ record.metadata.title }}</a>
+    <ng-template #titleWithoutLink>
+        {{ record.metadata.title }}
+    </ng-template>
+</h5>
 <p>
     <span class="badge badge-primary mr-1" *ngFor="let author of record.metadata.authors">{{ author.name }}</span>
 </p>

--- a/projects/ng-core-tester/src/app/record/document/document.component.ts
+++ b/projects/ng-core-tester/src/app/record/document/document.component.ts
@@ -10,4 +10,7 @@ export class DocumentComponent implements ResultItem {
 
   @Input()
   type: string;
+
+  @Input()
+  detailUrl: string;
 }

--- a/projects/ng-core-tester/src/app/record/institution/institution.component.html
+++ b/projects/ng-core-tester/src/app/record/institution/institution.component.html
@@ -1,2 +1,7 @@
-<h5>{{ record.metadata.name }}</h5>
+<h5>
+    <a href [routerLink]="detailUrl" *ngIf="detailUrl; else titleWithoutLink">{{ record.metadata.name }}</a>
+    <ng-template #titleWithoutLink>
+        {{ record.metadata.name }}
+    </ng-template>
+</h5>
 <p class="mb-0"><span class="badge badge-primary">{{ record.metadata.pid }}</span></p>

--- a/projects/ng-core-tester/src/app/record/institution/institution.component.ts
+++ b/projects/ng-core-tester/src/app/record/institution/institution.component.ts
@@ -10,4 +10,7 @@ export class InstitutionComponent implements ResultItem {
 
   @Input()
   type: string;
+
+  @Input()
+  detailUrl: string;
 }

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -63,7 +63,7 @@
                 <li class="list-group-item px-0 py-4" *ngFor="let record of records">
                     <ng-core-record-search-result [adminMode]="adminMode" [record]="record" [type]="currentType"
                         [itemViewComponent]="getResultItemComponentView()" [canUpdate]="canUpdateRecord(record)"
-                        [inRouting]="inRouting" [detailUrl]="detailUrl" [canDelete]="canDeleteRecord(record)"
+                        [inRouting]="inRouting" [canDelete]="canDeleteRecord(record)" [detailUrl$]="resolveDetailUrl(record)"
                         (deletedRecord)="deleteRecord($event)">
                     </ng-core-record-search-result>
                 </li>

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
@@ -62,7 +62,7 @@ describe('RecordSearchComponent', () => {
     snapshot: {
       data: {
         linkPrefix: '/records',
-        detailUrl: '/custom/url/for/detail',
+        detailUrl: '/custom/url/for/detail/:type/:pid',
         types: [
           {
             key: 'documents',
@@ -290,4 +290,31 @@ describe('RecordSearchComponent', () => {
     expect(component.aggFilters.length).toBe(1);
     expect(component.aggFilters[0].values).toEqual(['Filippini, Massimo']);
   });
+
+  it('should resolve detail url', async(() => {
+    component.resolveDetailUrl({ metadata: { pid: 100 } }).subscribe((result: any) => {
+      expect(result).toBe('/custom/url/for/detail/documents/100');
+    });
+
+    component.detailUrl = null;
+
+    component.resolveDetailUrl({ metadata: { pid: 100 } }).subscribe((result: any) => {
+      expect(result).toBe('detail/100');
+    });
+
+    component.types = [
+      {
+        key: 'documents',
+        label: 'Documents',
+        canRead: () => of(false)
+      }
+    ];
+    /* tslint:disable:no-string-literal */
+    component['loadResourceConfig']();
+
+    component.resolveDetailUrl({ metadata: { pid: 100 } }).subscribe((result: any) => {
+      expect(result).toBe(null);
+    });
+  }));
+
 });

--- a/projects/rero/ng-core/src/lib/record/search/result/item/json.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/result/item/json.component.ts
@@ -29,4 +29,7 @@ export class JsonComponent implements ResultItem {
 
   @Input()
   type: string;
+
+  @Input()
+  detailUrl: string;
 }

--- a/projects/rero/ng-core/src/lib/record/search/result/item/result-item.ts
+++ b/projects/rero/ng-core/src/lib/record/search/result/item/result-item.ts
@@ -17,4 +17,5 @@
 export interface ResultItem {
     record: any;
     type: string;
+    detailUrl: string;
 }

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
@@ -19,14 +19,9 @@
         <ng-template ngCoreRecordSearchResult></ng-template>
     </div>
     <div class="col-2 text-right">
-        <a [href]="formattedDetailUrl" *ngIf="detailUrl; else routingDetailLink">
+        <a href [routerLink]="detailUrl" *ngIf="detailUrl">
             <i class="fa fa-file-o"></i>
         </a>
-        <ng-template #routingDetailLink>
-            <a href="#" [title]="'Show'|translate" [routerLink]="['detail/', record.metadata.pid]" *ngIf="inRouting">
-                <i class="fa fa-file-o"></i>
-            </a>
-        </ng-template>
         <a class="ml-2" [title]="'Edit'|translate" routerLink="edit/{{ record.metadata.pid }}"
             *ngIf="inRouting && adminMode && canUpdate">
             <i class="fa fa-pencil"></i>

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.spec.ts
@@ -72,16 +72,4 @@ describe('RecordSearchResultComponent', () => {
     });
     component.deleteRecord(new Event('click'), '1');
   });
-
-  it('should resolve custom detail URL', () => {
-    component.record = {
-      id: '1',
-      metadata: {
-        pid: '1'
-      }
-    };
-    component.type = 'documents';
-    component.detailUrl = '/custom/url/to/detail/:type/:pid';
-    expect(component.formattedDetailUrl).toBe('/custom/url/to/detail/documents/1');
-  });
 });

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.ts
@@ -22,6 +22,7 @@ import { RecordSearchResultDirective } from './record-search-result.directive';
 import { JsonComponent } from './item/json.component';
 import { DialogService } from '../../../dialog/dialog.service';
 import { DeleteRecordStatus } from '../../record-status';
+import { ResultItem } from './item/result-item';
 
 @Component({
   selector: 'ng-core-record-search-result',
@@ -34,6 +35,11 @@ export class RecordSearchResultComponent implements OnInit {
   currentUrl: string = null;
 
   canDeleteResult: DeleteRecordStatus;
+
+  /**
+   * Detail URL value, resolved by observable property detailUrl$.
+   */
+  detailUrl: string;
 
   /**
    * Record to display
@@ -84,17 +90,10 @@ export class RecordSearchResultComponent implements OnInit {
   inRouting = false;
 
   /**
-   * URL to notice detail
+   * Observable emitting current value of record URL.
    */
   @Input()
-  detailUrl: string = null;
-
-  /**
-   * Return detail URL with replaced placeholders.
-   */
-  get formattedDetailUrl() {
-    return this.detailUrl.replace(':type', this.type).replace(':pid', this.record.id);
-  }
+  detailUrl$: Observable<string> = null;
 
   /**
    * Event emitted when a record is deleted
@@ -121,13 +120,19 @@ export class RecordSearchResultComponent implements OnInit {
    * Component init
    */
   ngOnInit() {
-    this.loadItemView();
-
     if (this.canDelete) {
       this.canDelete.subscribe((result: DeleteRecordStatus) => {
         this.canDeleteResult = result;
       });
     }
+
+    if (this.detailUrl$) {
+      this.detailUrl$.subscribe((url: string) => {
+        this.detailUrl = url;
+      });
+    }
+
+    this.loadItemView();
   }
 
   /**
@@ -140,8 +145,9 @@ export class RecordSearchResultComponent implements OnInit {
     viewContainerRef.clear();
 
     const componentRef = viewContainerRef.createComponent(componentFactory);
-    (componentRef.instance as JsonComponent).record = this.record;
-    (componentRef.instance as JsonComponent).type = this.type;
+    (componentRef.instance as ResultItem).record = this.record;
+    (componentRef.instance as ResultItem).type = this.type;
+    (componentRef.instance as ResultItem).detailUrl = this.detailUrl;
   }
 
   /**

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.directive.ts
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.directive.ts
@@ -14,17 +14,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Directive, ViewContainerRef, Input } from '@angular/core';
+import { Directive, ViewContainerRef } from '@angular/core';
 
 @Directive({
     selector: '[ngCoreRecordSearchResult]',
 })
 export class RecordSearchResultDirective {
-    /**
-     * Record to display
-     */
-    @Input()
-    record: object = {};
-
     constructor(public viewContainerRef: ViewContainerRef) { }
 }


### PR DESCRIPTION
* Injects detail URL in directive which manage result item display.
* Provides example for displaying link to detail
* Corrects error on certain documents details in tester.
* Changes "patrons" key to "users" for displaying SONAR users in tester.
* Fixes issue #23

Co-Authored-by: Olivier Dossmann <git@dossmann.net>
Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>