### PR TITLE
editor: fix submit button with async validator

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/add-reference/add-reference.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/add-reference/add-reference.component.ts
@@ -61,7 +61,6 @@ export class AddReferenceComponent implements OnInit {
 
   addItem(event) {
     event.preventDefault();
-    console.log(this);
     this.jsf.addItem(this);
   }
 

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -33,6 +33,7 @@ import { RolesCheckboxesComponent } from './roles-checkboxes/roles-checkboxes.co
 import { RemoteInputComponent } from './remote-input/remote-input.component';
 import { MainFieldsManagerComponent } from './main-fields-manager/main-fields-manager.component';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
+import { SubmitComponent } from './submit/submit.component';
 
 
 @Component({
@@ -99,6 +100,7 @@ export class EditorComponent implements OnInit {
     this.widgetLibrary.registerWidget('refAuthority', MefComponent);
     this.widgetLibrary.registerWidget('$ref', AddReferenceComponent);
     this.widgetLibrary.registerWidget('main-fields-manager', MainFieldsManagerComponent);
+    this.widgetLibrary.registerWidget('submit', SubmitComponent);
 
     this.currentLocale = this.translateService.currentLang;
   }
@@ -178,13 +180,5 @@ export class EditorComponent implements OnInit {
    */
   public cancel() {
     this.location.back();
-  }
-
-  /**
-   * Store errors in dedicated property
-   * @param errors - array, list of errors
-   */
-  public validationErrors(errors: []) {
-    this.formValidationErrors = errors;
   }
 }

--- a/projects/rero/ng-core/src/lib/record/editor/submit/submit.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/submit/submit.component.html
@@ -14,11 +14,18 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<header class="d-flex mb-4">
-  <h3 class="mb-0 mr-4">{{ recordType|translate }}</h3>
-  <button (click)="cancel()" class="btn btn-warning btn-sm" translate>Cancel</button>
-</header>
-
-<json-schema-form *ngIf="schemaForm" [form]="schemaForm" [model]="schemaForm.data" (onSubmit)="save($event)"
-    framework="custom" [language]="currentLocale" [options]="formOptions">
-</json-schema-form>
+<div
+[class]="options?.htmlClass || ''">
+  <input
+    [attr.aria-describedby]="'control' + layoutNode?._id + 'Status'"
+    [attr.readonly]="options?.readonly ? 'readonly' : null"
+    [attr.required]="options?.required"
+    [class]="options?.fieldHtmlClass || ''"
+    [disabled]="controlDisabled"
+    [id]="'control' + layoutNode?._id"
+    [name]="controlName"
+    [type]="layoutNode?.type"
+    [value]="controlValue"
+    (click)="updateValue($event)"
+  >
+</div>

--- a/projects/rero/ng-core/src/lib/record/editor/submit/submit.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/submit/submit.component.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SubmitComponent } from './submit.component';
+import { Bootstrap4FrameworkModule } from 'angular6-json-schema-form';
+
+describe('SubmitComponent', () => {
+  let component: SubmitComponent;
+  let fixture: ComponentFixture<SubmitComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SubmitComponent ],
+      imports: [
+          Bootstrap4FrameworkModule
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SubmitComponent);
+    component = fixture.componentInstance;
+    component.layoutNode = {
+        options: {
+            disabled: false
+        }
+     };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/editor/submit/submit.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/submit/submit.component.ts
@@ -1,0 +1,68 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AbstractControl } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { JsonSchemaFormService, hasOwn } from 'angular6-json-schema-form';
+import { combineLatest } from 'rxjs';
+
+@Component({
+  // tslint:disable-next-line:component-selector
+  selector: 'app-submit',
+  templateUrl: './submit.component.html'
+})
+export class SubmitComponent implements OnInit {
+  formControl: AbstractControl;
+  controlName: string;
+  controlValue: any;
+  controlDisabled = false;
+  boundControl = false;
+  options: any;
+  @Input() layoutNode: any;
+  @Input() layoutIndex: number[];
+  @Input() dataIndex: number[];
+  formValidCode = 'VALID';
+
+  constructor(
+    private jsf: JsonSchemaFormService
+  ) { }
+
+  ngOnInit() {
+    this.options = this.layoutNode.options || {};
+    this.jsf.initializeControl(this);
+    if (hasOwn(this.options, 'disabled')) {
+      this.controlDisabled = this.options.disabled;
+    } else if (this.jsf.formOptions.disableInvalidSubmit) {
+      this.controlDisabled = !(this.jsf.isValid && this.jsf.formGroup.status === this.formValidCode);
+      combineLatest(this.jsf.isValidChanges, this.jsf.formGroup.statusChanges)
+      .subscribe(([jsonSchemaValidChanges, formValidChanges]) => {
+          this.controlDisabled = !(jsonSchemaValidChanges && formValidChanges === this.formValidCode);
+      });
+    }
+    if (this.controlValue === null || this.controlValue === undefined) {
+      this.controlValue = this.options.title;
+    }
+  }
+
+  updateValue(event) {
+    if (typeof this.options.onClick === 'function') {
+      this.options.onClick(event);
+    } else {
+      this.jsf.updateValue(this, event.target.value);
+    }
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -38,6 +38,7 @@ import { RemoteSelectComponent } from './editor/remote-select/remote-select.comp
 import { RolesCheckboxesComponent } from './editor/roles-checkboxes/roles-checkboxes.component';
 import { MainFieldsManagerComponent } from './editor/main-fields-manager/main-fields-manager.component';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SubmitComponent } from './editor/submit/submit.component';
 
 @NgModule({
   declarations: [
@@ -57,7 +58,8 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
     RemoteInputComponent,
     RemoteSelectComponent,
     RolesCheckboxesComponent,
-    MainFieldsManagerComponent
+    MainFieldsManagerComponent,
+    SubmitComponent
   ],
   imports: [
     SharedModule,
@@ -81,7 +83,8 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
     RemoteInputComponent,
     RemoteSelectComponent,
     RolesCheckboxesComponent,
-    MainFieldsManagerComponent
+    MainFieldsManagerComponent,
+    SubmitComponent
   ]
 })
 export class RecordModule { }


### PR DESCRIPTION
* Disables submit button for invalid async validator: i.e. for item
  barcode uniqueness validation.
* Removes useless debug traces.
* Uses core unique validator for remote input component.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>