### PR TITLE
project: export custom bootstrap editor lib

### DIFF
--- a/projects/rero/ng-core/src/public-api.ts
+++ b/projects/rero/ng-core/src/public-api.ts
@@ -35,3 +35,4 @@ export * from './lib/translate/translate-loader';
 export * from './lib/translate/translate-service';
 export * from './lib/translate/date-translate-pipe';
 export * from './lib/record/record-status';
+export * from './lib/record/editor/bootstrap4-framework/custombootstrap4-framework';


### PR DESCRIPTION
Enable bootstrap4framework export to allow other applications to create JSON Schema forms with our tools.

**This is needed by https://tree.taiga.io/project/rero21-reroils/task/1094**.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>