### PR TITLE
search: fix url query params changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build-lib": "ng build @rero/ng-core",
+    "pack": "ng build @rero/ng-core; npm pack dist/rero/ng-core",
     "test-lib": "ng test @rero/ng-core",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
@@ -81,7 +81,8 @@ describe('RecordSearchComponent', () => {
         author: ['Filippini, Massimo']
       },
       paramMap: convertToParamMap({ type: 'documents' })
-    }
+    },
+    queryParams: of({})
   };
 
   beforeEach(async(() => {

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -167,7 +167,16 @@ export class RecordSearchComponent implements OnInit {
    * Component initialisation.
    */
   ngOnInit() {
-    // Load data from routing data. Only relevant when component is loaded into routing.
+    this.route.queryParams.subscribe(queryParams => {
+      this.loadData();
+    });
+  }
+
+  /** Load data from routing data.
+   *
+   * Only relevant when component is loaded into routing
+   */
+  loadData() {
     const data = this.route.snapshot.data;
     if (data.linkPrefix) {
       this.inRouting = true;


### PR DESCRIPTION
Changing the http query params update the search results.

* Adds a new alias for library build and pack -> `npm run pack`.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>