### PR TITLE
autocomplete: add search input with autocompletion

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -134,10 +134,6 @@ const routes: Routes = [
           preFilters: {
             institution: 'usi'
           }
-        },
-        {
-          key: 'users',
-          label: 'Utilisateurs'
         }
       ]
     }
@@ -209,10 +205,6 @@ const routes: Routes = [
           key: 'institutions',
           label: 'Organisations',
           component: InstitutionComponent
-        },
-        {
-          key: 'users',
-          label: 'Utilisateurs'
         }
       ]
     }

--- a/projects/ng-core-tester/src/app/app.component.html
+++ b/projects/ng-core-tester/src/app/app.component.html
@@ -25,6 +25,7 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent" [collapse]="isCollapsed" [isAnimated]="true">
       <ng-core-menu class="mr-auto" [menu]="linksMenu"></ng-core-menu>
       <ng-core-menu [menu]="languagesMenu" (clickItem)="changeLang($event)"></ng-core-menu>
+      <app-search-bar class="ml-md-2" viewcode="sonar" size="small"></app-search-bar>
     </div>
   </div>
 </nav>

--- a/projects/ng-core-tester/src/app/app.module.ts
+++ b/projects/ng-core-tester/src/app/app.module.ts
@@ -29,7 +29,8 @@ import { HomeComponent } from './home/home.component';
 import { DetailComponent } from './record/document/detail/detail.component';
 import { CoreConfigService } from '@rero/ng-core';
 import { AppConfigService } from './app-config.service';
-import { CollapseModule } from 'ngx-bootstrap';
+import { CollapseModule, TypeaheadModule } from 'ngx-bootstrap';
+import { SearchBarComponent } from './search-bar/search-bar.component';
 
 @NgModule({
   declarations: [
@@ -37,7 +38,8 @@ import { CollapseModule } from 'ngx-bootstrap';
     DocumentComponent,
     InstitutionComponent,
     HomeComponent,
-    DetailComponent
+    DetailComponent,
+    SearchBarComponent
   ],
   imports: [
     SharedModule,
@@ -47,7 +49,8 @@ import { CollapseModule } from 'ngx-bootstrap';
     AppRoutingModule,
     CoreModule,
     CollapseModule.forRoot(),
-    RecordModule
+    RecordModule,
+    TypeaheadModule.forRoot()
   ],
   providers: [
     {

--- a/projects/ng-core-tester/src/app/home/home.component.ts
+++ b/projects/ng-core-tester/src/app/home/home.component.ts
@@ -23,10 +23,6 @@ export class HomeComponent {
       key: 'institutions',
       label: 'Organisations',
       component: InstitutionComponent
-    },
-    {
-      key: 'patrons',
-      label: 'Utilisateurs'
     }
   ];
 

--- a/projects/ng-core-tester/src/app/search-bar/search-bar.component.html
+++ b/projects/ng-core-tester/src/app/search-bar/search-bar.component.html
@@ -1,0 +1,25 @@
+<!--
+ Invenio angular core
+ Copyright (C) 2019 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-core-autocomplete
+    [recordTypes]="recordTypes"
+    [action]="action"
+    [internalRouting]="false"
+    [size]="size"
+    [buttonCssClass]="'btn btn-outline-primary'"
+    class="flex-grow-1">
+</ng-core-autocomplete>

--- a/projects/ng-core-tester/src/app/search-bar/search-bar.component.spec.ts
+++ b/projects/ng-core-tester/src/app/search-bar/search-bar.component.spec.ts
@@ -1,0 +1,57 @@
+/*
+* Invenio angular core
+* Copyright (C) 2019 RERO
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, version 3 of the License.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchBarComponent } from './search-bar.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { TypeaheadModule } from 'ngx-bootstrap';
+import { AutocompleteComponent, SharedModule } from '@rero/ng-core';
+
+describe('SearchBarComponent', () => {
+  let component: SearchBarComponent;
+  let fixture: ComponentFixture<SearchBarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SearchBarComponent, AutocompleteComponent ],
+      imports: [
+        RouterTestingModule,
+        HttpClientModule,
+        FormsModule,
+        ReactiveFormsModule,
+        TranslateModule.forRoot(),
+        TypeaheadModule.forRoot(),
+        SharedModule
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ng-core-tester/src/app/search-bar/search-bar.component.ts
+++ b/projects/ng-core-tester/src/app/search-bar/search-bar.component.ts
@@ -1,0 +1,104 @@
+/*
+* Invenio angular core
+* Copyright (C) 2019 RERO
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, version 3 of the License.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Component, OnInit, Input } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-search-bar',
+  templateUrl: './search-bar.component.html'
+})
+export class SearchBarComponent implements OnInit {
+
+  @Input() viewcode: string;
+  @Input() size: string = undefined;
+  @Input() maxLengthSuggestion = 100;
+
+
+  get action() {
+    return `/records/documents`;
+  }
+
+  recordTypes = [];
+
+  static getPersonName(metadata) {
+    for (const source of ['rero', 'bnf', 'gnd']) {
+      if (metadata[source] && metadata[source].preferred_name_for_person) {
+        return metadata[source].preferred_name_for_person;
+      }
+    }
+  }
+
+  constructor(private translateService: TranslateService) {
+   }
+
+  ngOnInit() {
+    this.recordTypes = [{
+      type: 'documents',
+      field: 'title',
+      getSuggestions: (query, persons) => this.getDocumentsSuggestions(query, persons),
+      preFilters: this.viewcode ? {view: this.viewcode} : {}
+    }, {
+      type: 'institutions',
+      field: 'name',
+      getSuggestions: (query, persons) => this.getInstitutionsSuggestions(query, persons),
+      component: this,
+      preFilters: this.viewcode ? {view: this.viewcode} : {}
+    }];
+  }
+
+  getInstitutionsSuggestions(query, institutions) {
+    const values = [];
+    institutions.hits.hits.map(hit => {
+      let text = hit.metadata.name;
+      text = text.replace(new RegExp(query, 'gi'), `<b>${query}</b>`);
+      values.push({
+        text,
+        query: '',
+        index: 'institutions',
+        category: this.translateService.instant('direct links'),
+        href: `/records/institutions/detail/${hit.metadata.pid}`,
+        iconCssClass: 'fa fa-bank'
+      });
+    });
+    return values;
+  }
+
+  getDocumentsSuggestions(query, documents) {
+    const values = [];
+    documents.hits.hits.map(hit => {
+      let text = hit.metadata.title;
+      let truncate = false;
+      if (text.length > this.maxLengthSuggestion) {
+        truncate = true;
+        text = hit.metadata.title.substr(0, this.maxLengthSuggestion);
+      }
+      text = text.replace(new RegExp(query, 'gi'), `<b>${query}</b>`);
+      if (truncate) {
+        text = text + ' ...';
+      }
+      values.push({
+        text,
+        query: hit.metadata.title.replace(/[:\-\[\]()/"]/g, ' ').replace(/\s\s+/g, ' '),
+        index: 'documents',
+        category: this.translateService.instant('documents')
+        // href: `/${this.viewcode}/documents/${hit.metadata.pid}`
+      });
+    });
+    return values;
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.html
+++ b/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.html
@@ -1,0 +1,53 @@
+<!--
+ Invenio angular core
+ Copyright (C) 2019 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-template #customItemTemplate let-match="match" let-query="query" let-model="item" let-index="index">
+  <span *ngIf="model.iconCssClass"><i [ngClass]="model.iconCssClass" aria-hidden="true"></i>&nbsp;</span>
+  <span [innerHtml]="model.text"></span>
+</ng-template>
+
+<form #form class="rero-ils-autocomplete input-group" action="{{ action }}"
+      [ngClass]="{'input-group-lg': size === 'large', 'input-group-sm': size === 'small'}"
+      role="search" autocomplete="off">
+
+  <input
+  (keyup.enter)="doSearch($event)"
+  name="q"
+  [placeholder]="placeholder? placeholder: 'search' | translate | ucfirst"
+  [(ngModel)]="asyncSelected.query"
+  [typeaheadAsync]="true"
+  [typeahead]="dataSource"
+  (typeaheadLoading)="changeTypeaheadLoading($event)"
+  [typeaheadOptionsLimit]="typeaheadOptionsLimit"
+  typeaheadOptionField="query"
+  class="form-control"
+  [typeaheadWaitMs]="typeaheadWaitMs"
+  [typeaheadMinLength]="typeaheadMinLength"
+  [typeaheadItemTemplate]="customItemTemplate"
+  typeaheadGroupField="category"
+  (typeaheadOnSelect)="typeaheadOnSelect($event)"
+  [typeaheadIsFirstItemActive]="false"
+  >
+  <input type="hidden" name="size" value="10">
+  <input type="hidden" name="page" value="1">
+  <div class="input-group-append">
+    <button type="submit" (click)="doSearch($event)" [ngClass]="buttonCssClass">
+      <i *ngIf="!typeaheadLoading" class="fa fa-search"></i>
+      <i *ngIf="typeaheadLoading" class="fa fa-spinner fa-spin"></i>
+    </button>
+  </div>
+</form>

--- a/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AutocompleteComponent } from './autocomplete.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TypeaheadModule } from 'ngx-bootstrap';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+import { TranslateModule } from '@ngx-translate/core';
+import { SharedModule } from '../../shared.module';
+
+describe('AutocompleteComponent', () => {
+  let component: AutocompleteComponent;
+  let fixture: ComponentFixture<AutocompleteComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientModule,
+        FormsModule,
+        TypeaheadModule.forRoot(),
+        RouterTestingModule,
+        TranslateModule.forRoot(),
+        SharedModule
+      ],
+      declarations: [ AutocompleteComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AutocompleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.ts
+++ b/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.ts
@@ -1,0 +1,199 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { TypeaheadMatch } from 'ngx-bootstrap';
+import { Observable, of, combineLatest } from 'rxjs';
+import { mergeMap, map } from 'rxjs/operators';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RecordService } from '../record.service';
+
+
+@Component({
+  selector: 'ng-core-autocomplete',
+  templateUrl: './autocomplete.component.html'
+})
+export class AutocompleteComponent implements OnInit {
+
+  /** The current form object from the template. */
+  @ViewChild('form', {static: false}) form;
+
+  /** The current selected suggestion. */
+  asyncSelected = {
+    text: undefined,
+    query: undefined,
+    index: undefined,
+    category: undefined,
+    href: undefined
+  };
+
+  /** The submit button css class. */
+  @Input() buttonCssClass = 'btn btn-light';
+
+  /** The remote suggestions loading status. */
+  typeaheadLoading: boolean;
+
+  /** The remote suggestions list. */
+  dataSource: Observable<any>;
+
+  /** The form action i.e. '/search' */
+  @Input() action: string;
+
+  /** The autocomplete record type configuration. */
+  @Input()
+  recordTypes: Array<any> = [];
+
+  /** The search input field size: small or large */
+  @Input() size: string;
+
+  /** The search input field placeholder. */
+  @Input() placeholder: string;
+
+  /** The routing mode, angular for internal or href for external. */
+  @Input() internalRouting = true;
+
+  // debug information
+  // @Input() displayScore = undefined;
+
+  /** The minimal number of characters that needs to be entered before typeahead kicks-in. */
+  @Input() typeaheadMinLength = 3;
+
+  /** The minimal wait time after last character typed before typeahead kicks-in. */
+  @Input() typeaheadWaitMs = 300;
+
+  /** The maximum length of options items list. The default value is 20. */
+  @Input() typeaheadOptionsLimit = 10;
+
+  // store a current URL redirection
+  private redirect = false;
+
+  /**
+   * Constructor
+   * @param recordService - REST API record service
+   * @param route - Angular current route
+   * @param router - Angular router for navigation
+   */
+  constructor(
+    private recordService: RecordService,
+    private route: ActivatedRoute,
+    private router: Router) {
+    }
+
+  /**
+   * On init hook
+   */
+  ngOnInit() {
+    this.route.queryParamMap.subscribe((params: any) => {
+      // if (params.get('display_score')) {
+      //   this.displayScore = params.get('display_score');
+      // }
+
+      // get the query form the URL
+      const query = params.get('q');
+      if (query) {
+        this.asyncSelected = {
+          query,
+          text: query,
+          index: undefined,
+          category: undefined,
+          href: undefined
+        };
+      }
+      this.dataSource = new Observable((observer: any) => {
+        // Runs on every search
+        observer.next(this.asyncSelected);
+      })
+      .pipe(
+        mergeMap((asyncSelected: any) => this.getSuggestions(asyncSelected.query))
+        );
+    });
+  }
+
+  /**
+   * Apply search action
+   * @param event - Event, DOM event
+   */
+  doSearch(event) {
+    event.preventDefault();
+    if (!this.redirect) {
+      if (this.internalRouting) {
+        this.router.navigate([this.action], { queryParams: {q: this.asyncSelected.query, page: '1', size: '10'}});
+      } else {
+        this.form.nativeElement.submit();
+      }
+    }
+  }
+
+  /**
+   * Get remote suggestions
+   * @param query - string, search query string
+   */
+  getSuggestions(query: string): Observable<any> {
+    // patch non working typeaheadMinLength properties
+    if (query.length < this.typeaheadMinLength) {
+      return of(undefined);
+    }
+    const combineGetRecords = [];
+    const recordTypesKeys = this.recordTypes.map(recordType => recordType.type);
+    this.recordTypes.forEach(recordType => {
+      combineGetRecords.push(
+        this.recordService.getRecords(
+          recordType.type, `${recordType.field}:${query}`, 1,
+          recordType.maxNumberOfSuggestions ? recordType.maxNumberOfSuggestions : 10, [],
+          recordType.preFilters ? recordType.preFilters : {}));
+    });
+    return combineLatest(
+      combineGetRecords
+      )
+    .pipe(
+      map(
+        (getRecordsValues: Array<any>) => {
+          // add query at the top
+          let values = [];
+          recordTypesKeys.forEach((recordType, index) => {
+            values = values.concat(
+              this.recordTypes[index].getSuggestions(
+                query, getRecordsValues[index]));
+          });
+          return values;
+        })
+      );
+  }
+
+  /**
+   * Store the loading state
+   * @param e - boolean, true if loading
+   */
+  changeTypeaheadLoading(e: boolean): void {
+    this.typeaheadLoading = e;
+  }
+
+  /**
+   * A suggestion is selected
+   * @param e - TypeaheadMatch, contains the selected suggestion
+   */
+  typeaheadOnSelect(e: TypeaheadMatch): void {
+    if (e.item.href) {
+      if (this.internalRouting) {
+        this.router.navigate([e.item.href]);
+      } else {
+        window.location.href = e.item.href;
+      }
+      this.redirect = true;
+    }
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -39,6 +39,7 @@ import { RolesCheckboxesComponent } from './editor/roles-checkboxes/roles-checkb
 import { MainFieldsManagerComponent } from './editor/main-fields-manager/main-fields-manager.component';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { SubmitComponent } from './editor/submit/submit.component';
+import { AutocompleteComponent } from './autocomplete/autocomplete.component';
 
 @NgModule({
   declarations: [
@@ -59,7 +60,8 @@ import { SubmitComponent } from './editor/submit/submit.component';
     RemoteSelectComponent,
     RolesCheckboxesComponent,
     MainFieldsManagerComponent,
-    SubmitComponent
+    SubmitComponent,
+    AutocompleteComponent
   ],
   imports: [
     SharedModule,
@@ -71,7 +73,8 @@ import { SubmitComponent } from './editor/submit/submit.component';
     TypeaheadModule.forRoot()
   ],
   exports: [
-    RecordSearchComponent
+    RecordSearchComponent,
+    AutocompleteComponent
   ],
   entryComponents: [
     JsonComponent,
@@ -84,7 +87,8 @@ import { SubmitComponent } from './editor/submit/submit.component';
     RemoteSelectComponent,
     RolesCheckboxesComponent,
     MainFieldsManagerComponent,
-    SubmitComponent
+    SubmitComponent,
+    AutocompleteComponent
   ]
 })
 export class RecordModule { }

--- a/projects/rero/ng-core/src/public-api.ts
+++ b/projects/rero/ng-core/src/public-api.ts
@@ -35,4 +35,5 @@ export * from './lib/translate/translate-loader';
 export * from './lib/translate/translate-service';
 export * from './lib/translate/date-translate-pipe';
 export * from './lib/record/record-status';
+export * from './lib/record/autocomplete/autocomplete.component';
 export * from './lib/record/editor/bootstrap4-framework/custombootstrap4-framework';

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,6 +28,8 @@ display_success_message () {
     echo -e "${GREEN}$1${NC}" 1>&2
 }
 
+set -e
+
 display_success_message "Building library..."
 ng build @rero/ng-core
 


### PR DESCRIPTION
* Adds a new search input component with a remote autocomplete feature.
* Fixes patrons not found error on tester.
* Improves `run-tests.sh`: it failed in case of error.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Sébastion Délèze <sebastien-deleze@rero.ch>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>