### PR TITLE
records: search refactoring

### DIFF
--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -19,6 +19,7 @@ import { Bootstrap4FrameworkModule } from 'angular6-json-schema-form';
 
 import { RecordRoutingModule } from './record-routing.module';
 import { RecordSearchComponent } from './search/record-search.component';
+import { RecordSearchComponent as RecordSearchPageComponent } from './search/record-search-page.component';
 import { RecordSearchResultComponent } from './search/result/record-search-result.component';
 import { RecordSearchResultDirective } from './search/result/record-search-result.directive';
 import { RecordSearchAggregationComponent } from './search/aggregation/aggregation.component';
@@ -43,6 +44,7 @@ import { AutocompleteComponent } from './autocomplete/autocomplete.component';
 
 @NgModule({
   declarations: [
+    RecordSearchPageComponent,
     RecordSearchComponent,
     RecordSearchResultComponent,
     RecordSearchResultDirective,

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.html
@@ -1,0 +1,21 @@
+<!--
+ Invenio angular core
+ Copyright (C) 2019 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-core-record-search [adminMode]="true" [currentType]="currentType" [types]="types" [detailUrl]="detailUrl"
+    [showSearchInput]="showSearchInput" [aggFilters]="aggFilters" [q]="q" [page]="page" [size]="size" [inRouting]="true"
+    (parametersChanged)="updateUrl($event)">
+</ng-core-record-search>

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.spec.ts
@@ -1,0 +1,137 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router, ActivatedRoute, convertToParamMap } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { TranslateModule, TranslateLoader, TranslateFakeLoader } from '@ngx-translate/core';
+import { PaginationModule, ModalModule } from 'ngx-bootstrap';
+import { ToastrModule } from 'ngx-toastr';
+
+import { RecordSearchComponent } from './record-search-page.component';
+import { DefaultPipe } from '../../pipe/default.pipe';
+import { UpperCaseFirstPipe } from '../../pipe/ucfirst.pipe';
+import { SearchInputComponent } from '../../search-input/search-input.component';
+import { RecordSearchAggregationComponent } from './aggregation/aggregation.component';
+import { RecordSearchResultComponent } from './result/record-search-result.component';
+import { RecordService } from '../record.service';
+import { DialogComponent } from '../../dialog/dialog.component';
+import { Nl2brPipe } from '../../pipe/nl2br.pipe';
+import { DialogService } from '../../dialog/dialog.service';
+import { TranslateLanguagePipe } from '../../translate-language/translate-language.pipe';
+
+describe('RecordSearchComponent', () => {
+  let component: RecordSearchComponent;
+  let fixture: ComponentFixture<RecordSearchComponent>;
+
+  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+  routerSpy.url = '';
+
+  const emptyRecords = {
+    aggregations: {},
+    hits: {
+      total: 2
+    },
+    links: {}
+  };
+
+  const recordServiceSpy = jasmine.createSpyObj('RecordService', ['getRecords', 'delete']);
+  recordServiceSpy.getRecords.and.returnValue(of(emptyRecords));
+  recordServiceSpy.delete.and.returnValue(of({}));
+
+  const dialogServiceSpy = jasmine.createSpyObj('DialogService', ['show']);
+  dialogServiceSpy.show.and.returnValue(of(true));
+
+  const route = {
+    snapshot: {
+      data: {
+        detailUrl: '/custom/url/for/detail/:type/:pid',
+        types: [
+          {
+            key: 'documents',
+          },
+          {
+            key: 'institutions',
+          }
+        ],
+        showSearchInput: true,
+        adminMode: true
+      },
+      queryParams: {
+        q: '',
+        page: 1,
+        size: 10,
+        author: ['Filippini, Massimo']
+      },
+      paramMap: convertToParamMap({ type: 'documents' }),
+      params: { type: 'documents' }
+    },
+    queryParams: of({})
+  };
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        SearchInputComponent,
+        RecordSearchAggregationComponent,
+        RecordSearchComponent,
+        RecordSearchResultComponent,
+        DefaultPipe,
+        UpperCaseFirstPipe,
+        Nl2brPipe,
+        DialogComponent,
+        TranslateLanguagePipe
+      ],
+      imports: [
+        BrowserAnimationsModule,
+        FormsModule,
+        TranslateModule.forRoot({
+          loader: { provide: TranslateLoader, useClass: TranslateFakeLoader }
+        }),
+        PaginationModule.forRoot(),
+        ModalModule.forRoot(),
+        ToastrModule.forRoot()
+      ],
+      providers: [
+        { provide: RecordService, useValue: recordServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ActivatedRoute, useValue: route },
+        { provide: DialogService, useValue: dialogServiceSpy },
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
+    })
+      .overrideModule(BrowserDynamicTestingModule, {
+        set: {
+          entryComponents: [DialogComponent],
+        }
+      })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecordSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -1,0 +1,185 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { combineLatest } from 'rxjs';
+
+@Component({
+  selector: 'ng-core-record-search-page',
+  templateUrl: './record-search-page.component.html',
+  styles: []
+})
+export class RecordSearchComponent implements OnInit {
+  /**
+   * Current filters applied
+   */
+  aggFilters = [];
+
+  /**
+   * Current selected resource type
+   */
+  currentType = 'documents';
+
+  /**
+   * URL to notice detail
+   */
+  detailUrl: string = null;
+
+  /**
+   * Display search input
+   */
+  showSearchInput = true;
+
+  /**
+   * Admin mode (edit, remove, add, ...)
+   */
+  adminMode = true;
+
+  /**
+   * Define the current record's page
+   */
+  page = 1;
+
+  /**
+   * Define the number of records per page
+   */
+  size = 10;
+
+  /**
+   * Search query
+   */
+  q = '';
+
+  /**
+   * Types of resources available
+   */
+  types: {
+    key: string,
+    label: string,
+    component?: Component,
+    total?: number,
+    canAdd?: any,
+    canUpdate?: any,
+    canDelete?: any,
+    canRead?: any,
+    aggregations?: any
+  }[] = [{ key: 'documents', label: 'Documents' }];
+
+  /**
+   * Constructor
+   * @param dialogService - Modal component
+   * @param recordService - Service for managing records
+   * @param toastService - Toast message
+   * @param route - Angular current route
+   * @param router - Angular router
+   */
+  constructor(
+    private route: ActivatedRoute,
+    protected router: Router
+  ) { }
+
+  /**
+   * Component initialisation.
+   */
+  ngOnInit() {
+    combineLatest(this.route.paramMap, this.route.queryParamMap).subscribe(([paramMap, queryParams]) => {
+      // store current type of resource
+      this.currentType = paramMap.get('type');
+
+      // store query parameters
+      if (queryParams.has('q')) {
+        this.q = queryParams.get('q');
+      }
+
+      if (queryParams.has('size')) {
+        this.size = +queryParams.get('size');
+      }
+
+      if (queryParams.has('page')) {
+        this.page = +queryParams.get('page');
+      }
+
+      // loop over all aggregation filters
+      queryParams.keys.forEach((key: string) => {
+        if (['q', 'page', 'size'].includes(key) === false) {
+          const values = queryParams.getAll(key);
+          const index = this.aggFilters.findIndex(item => item.key === key);
+
+          if (index !== -1) {
+            this.aggFilters[index] = { key, values };
+          } else {
+            this.aggFilters.push({ key, values });
+          }
+        }
+      });
+    });
+
+    // Store configuration data
+    const data = this.route.snapshot.data;
+    if (data.types) {
+      this.types = data.types;
+    }
+
+    if (typeof data.showSearchInput !== 'undefined') {
+      this.showSearchInput = data.showSearchInput;
+    }
+
+    if (typeof data.adminMode !== 'undefined') {
+      this.adminMode = data.adminMode;
+    }
+
+    if (data.detailUrl) {
+      this.detailUrl = data.detailUrl;
+    }
+  }
+
+  /**
+   * Update URL accordingly to parameters given.
+   * @param parameters Parameters to put in url or query string
+   */
+  updateUrl(parameters: any) {
+    const queryParams: any = {
+      q: parameters.q,
+      page: parameters.page,
+      size: parameters.size
+    };
+
+    for (const filter of parameters.aggFilters) {
+      // We need to loop over each value and insert it on beginning of the array
+      // instead of assign values directly. Otherwise, angular router doesn't
+      // detect the changes. It's certainly a bug in angular.
+      queryParams[filter.key] = [];
+      for (const value of filter.values) {
+        queryParams[filter.key].unshift(value);
+      }
+    }
+
+    this.router.navigate([this.getCurrentUrl(parameters.currentType)], { queryParams, relativeTo: this.route });
+  }
+
+  /**
+   * Return current URL after removing query parameters and updating resource type.
+   *
+   * @returns Updated url without query string
+   */
+  private getCurrentUrl(type: string): string {
+    const segments = this.router.parseUrl(this.router.url).root.children.primary.segments.map(it => it.path);
+    segments[segments.length - 1] = type;
+
+    return '/' + segments.join('/');
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -65,8 +65,8 @@
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item px-0 py-4" *ngFor="let record of records">
                         <ng-core-record-search-result [adminMode]="adminMode" [record]="record" [type]="currentType"
-                            [itemViewComponent]="getResultItemComponentView()" [canUpdate$]="canUpdateRecord(record)"
-                            [inRouting]="inRouting" [canDelete$]="canDeleteRecord(record)"
+                            [itemViewComponent]="getResultItemComponentView()" [canUpdate$]="canUpdateRecord$(record)"
+                            [inRouting]="inRouting" [canDelete$]="canDeleteRecord$(record)"
                             [detailUrl$]="resolveDetailUrl(record)" (deletedRecord)="deleteRecord($event)">
                         </ng-core-record-search-result>
                     </li>

--- a/projects/rero/ng-core/src/public-api.ts
+++ b/projects/rero/ng-core/src/public-api.ts
@@ -26,7 +26,7 @@ export * from './lib/translate-language/translate-language.service';
 export * from './lib/record/search/result/item/result-item';
 export * from './lib/record/record.module';
 export * from './lib/record/editor/editor.component';
-export * from './lib/record/search/record-search.component';
+export * from './lib/record/search/record-search-page.component';
 export * from './lib/record/detail/detail.component';
 export * from './lib/utils/utils';
 export * from './lib/validator/unique.validator';


### PR DESCRIPTION
* Splits RecordSearchComponent in two components, one for integration in template and one for routing.
* Moves check permissions to RecordUiService.
* Fixes #45.

Co-Authored-by: Sébastion Délèze <sebastien-deleze@rero.ch>