### PR TITLE
git: add PR and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+---
+name: Default Issue template
+about: Create an issue to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Describe the issue**
+A clear and concise description of what the issue is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '…'
+1. Log in as '…'
+1. Click on '…'
+1. Scroll down to '…'
+1. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Software version**
+Tell us which version you're using:
+
+  * from which server URL do you come from? ils.test or ilsdev?
+  * checks the version on homepage. Do you see the version as 0.5.0 or a hash as 2493ca6?
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Why are you opening this PR?
+
+- Which task/US does it implement?
+- Which issue does it fix?
+
+## How to test?
+
+- What command should I have to run to test your PR?
+- What should I test through the UI?
+
+## Code review check list
+
+- [ ] Commit message template compliance.
+- [ ] Commit message without typos.
+- [ ] File names.
+- [ ] Functions names.
+- [ ] Functions docstrings.
+- [ ] Unnecessary commited files?


### PR DESCRIPTION
* NEW Adds default PR and issue template.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To use same the templates than rero-ils (projects standardization)

## How to test?

N/A

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?