### PR TITLE
routing: fix routing issues

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -21,9 +21,6 @@ import { of, Observable } from 'rxjs';
 import { HomeComponent } from './home/home.component';
 import { DocumentComponent } from './record/document/document.component';
 import { DetailComponent } from './record/document/detail/detail.component';
-import { EditorComponent } from '@rero/ng-core';
-import { RecordSearchComponent } from '@rero/ng-core';
-import { DetailComponent as RecordDetailComponent } from '@rero/ng-core';
 import { ActionStatus } from 'projects/rero/ng-core/src/public-api';
 
 const canAdd = (record: any): Observable<ActionStatus> => {
@@ -60,8 +57,7 @@ const aggregations = (agg: object) => {
 
 export function matchedUrl(url: UrlSegment[]) {
   const segments = [
-    new UrlSegment(url[0].path, {}),
-    new UrlSegment(url[1].path, {})
+    new UrlSegment(url[0].path, {})
   ];
 
   return {
@@ -82,10 +78,7 @@ const routes: Routes = [
       }
       return null;
     },
-    children: [
-      { path: '', component: RecordSearchComponent },
-      { path: 'detail/:pid', component: RecordDetailComponent }
-    ],
+    loadChildren: () => import('@rero/ng-core').then(m => m.RecordModule),
     data: {
       showSearchInput: true,
       adminMode: false,
@@ -93,10 +86,7 @@ const routes: Routes = [
         {
           key: 'documents',
           label: 'Documents',
-          component: DocumentComponent,
-          preFilters: {
-            institution: 'usi'
-          }
+          component: DocumentComponent
         }
       ]
     }
@@ -108,10 +98,7 @@ const routes: Routes = [
       }
       return null;
     },
-    children: [
-      { path: '', component: RecordSearchComponent },
-      { path: 'detail/:pid', component: RecordDetailComponent }
-    ],
+    loadChildren: () => import('@rero/ng-core').then(m => m.RecordModule),
     data: {
       showSearchInput: true,
       adminMode: false,
@@ -125,10 +112,7 @@ const routes: Routes = [
   },
   {
     path: 'usi/record/search',
-    children: [
-      { path: ':type', component: RecordSearchComponent },
-      { path: ':type/detail/:pid', component: RecordDetailComponent }
-    ],
+    loadChildren: () => import('@rero/ng-core').then(m => m.RecordModule),
     data: {
       showSearchInput: true,
       adminMode: false,
@@ -146,10 +130,7 @@ const routes: Routes = [
   },
   {
     path: 'hevs/record/search',
-    children: [
-      { path: ':type', component: RecordSearchComponent },
-      { path: ':type/detail/:pid', component: RecordDetailComponent }
-    ],
+    loadChildren: () => import('@rero/ng-core').then(m => m.RecordModule),
     data: {
       showSearchInput: true,
       adminMode: false,
@@ -167,10 +148,7 @@ const routes: Routes = [
   },
   {
     path: 'record/search',
-    children: [
-      { path: ':type', component: RecordSearchComponent },
-      { path: ':type/detail/:pid', component: RecordDetailComponent }
-    ],
+    loadChildren: () => import('@rero/ng-core').then(m => m.RecordModule),
     data: {
       showSearchInput: true,
       adminMode: false,
@@ -185,12 +163,7 @@ const routes: Routes = [
   },
   {
     path: 'admin/record/search',
-    children: [
-      { path: ':type', component: RecordSearchComponent },
-      { path: ':type/detail/:pid', component: RecordDetailComponent },
-      { path: ':type/edit/:pid', component: EditorComponent },
-      { path: ':type/new', component: EditorComponent }
-    ],
+    loadChildren: () => import('@rero/ng-core').then(m => m.RecordModule),
     data: {
       types: [
         {

--- a/projects/rero/ng-core/src/lib/record/record-routing.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record-routing.module.ts
@@ -17,7 +17,7 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-import { RecordSearchComponent } from './search/record-search.component';
+import { RecordSearchComponent } from './search/record-search-page.component';
 import { EditorComponent } from './editor/editor.component';
 import { DetailComponent } from './detail/detail.component';
 

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.html
@@ -15,7 +15,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<ng-core-record-search [adminMode]="true" [currentType]="currentType" [types]="types" [detailUrl]="detailUrl"
+<ng-core-record-search [adminMode]="adminMode" [currentType]="currentType" [types]="types" [detailUrl]="detailUrl"
     [showSearchInput]="showSearchInput" [aggFilters]="aggFilters" [q]="q" [page]="page" [size]="size" [inRouting]="true"
     (parametersChanged)="updateUrl($event)">
 </ng-core-record-search>

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -134,11 +134,11 @@ export class RecordSearchComponent implements OnInit {
       this.types = data.types;
     }
 
-    if (typeof data.showSearchInput !== 'undefined') {
+    if (data.showSearchInput != null) {
       this.showSearchInput = data.showSearchInput;
     }
 
-    if (typeof data.adminMode !== 'undefined') {
+    if (data.adminMode != null) {
       this.adminMode = data.adminMode;
     }
 


### PR DESCRIPTION
* Uses RecordSearchPageComponent for record routing.
* Lazy-loads routes from ng-core for records in ng-core-tester.
* Takes into account the adminMode parameter in RecordSearchComponent.
* Changes conditions for retrieving adminMode and showSearchInput parameters from data.

Co-Authored-by: Sébastien Délèze sebastien-deleze@rero.ch
