### PR TITLE
module: fix translate module import for lazy loading

### DIFF
--- a/projects/rero/ng-core/src/lib/core.module.ts
+++ b/projects/rero/ng-core/src/lib/core.module.ts
@@ -50,7 +50,7 @@ import { ToastrModule } from 'ngx-toastr';
   imports: [
     CommonModule,
     RouterModule,
-    TranslateModule.forRoot({
+    TranslateModule.forChild({
       loader: {
         provide: BaseTranslateLoader,
         useClass: TranslateLoader

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -17,7 +17,6 @@
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 
-import { TranslateModule } from '@ngx-translate/core';
 import { Bootstrap4FrameworkModule } from 'angular6-json-schema-form';
 import { TooltipModule, TypeaheadModule, PaginationModule, CollapseModule } from 'ngx-bootstrap';
 
@@ -92,7 +91,6 @@ import { MenuComponent } from '../widget/menu/menu.component';
     PaginationModule.forRoot()
   ],
   exports: [
-    TranslateModule,
     DialogComponent,
     SearchInputComponent,
     MenuComponent,
@@ -105,7 +103,8 @@ import { MenuComponent } from '../widget/menu/menu.component';
     UpperCaseFirstPipe,
     CallbackArrayFilterPipe,
     DateTranslatePipe,
-    GetRecordPipe
+    GetRecordPipe,
+    CoreModule
   ],
   entryComponents: [
     JsonComponent,


### PR DESCRIPTION
* Configures ngx-translate to be used in a lazy loading module.
* Exports CoreModule in RecordModule.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
