### PR TITLE
records: search refactor

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -118,8 +118,12 @@ export class RecordSearchComponent implements OnInit {
       if (queryParams.has('q')) {
         this.q = queryParams.get('q');
       } else {
+        this.q = '';
+        this.size = 10;
+        this.page = 1;
+        this.aggFilters = [];
         // if no query params is set, put defaults in url
-        this.updateUrl({ currentType: this.currentType, q: this.q, size: this.size, page: this.page, aggFilters: [] });
+        this.updateUrl({ currentType: this.currentType, q: this.q, size: this.size, page: this.page, aggFilters: this.aggFilters });
       }
 
       if (queryParams.has('size')) {


### PR DESCRIPTION
* Removes useless component RecordSearchPage.
* Refactors RecordSearchComponent.
* Unsubscribes from route observables on component destruction.
* Removes standalone RecordSearchComponent integration.
* Fixes #86.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>