### PR TITLE
editor: custom select options

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -53,6 +53,10 @@ const canRead = (record: any): Observable<ActionStatus> => {
   });
 };
 
+const customSelectForType = (): Observable<Array<{ label: string, value: string }>> => {
+  return of([ { label: 'Custom type for document 1', value: 'type-1' }, { label: 'Custom type for document 2', value: 'type-2' } ]);
+};
+
 const aggregations = (agg: object) => {
   return of(agg);
 };
@@ -231,6 +235,9 @@ const routes: Routes = [
           },
           itemHeaders: {
             'Content-Type': 'application/rero+json'
+          },
+          form: {
+            type: customSelectForType
           }
         },
         {

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -137,7 +137,8 @@ import {ToggleWrapperComponent} from './editor/toggle-wrapper/toggle-wrappers.co
         { name: 'array', component: ArrayTypeComponent },
         { name: 'object', component: ObjectTypeComponent },
         { name: 'multischema', component: MultiSchemaTypeComponent },
-        { name: 'datepicker', component: DatepickerTypeComponent }
+        { name: 'datepicker', component: DatepickerTypeComponent },
+        { name: 'custom-select', extends: 'select' }
       ],
       wrappers: [
         { name: 'toggle-switch', component: ToggleWrapperComponent }

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -90,7 +90,8 @@ export class RecordSearchComponent implements OnInit {
     pagination?: {
       boundaryLinks?: boolean,
       maxSize?: number
-    }
+    },
+    form?: object
   }[] = [{ key: 'documents', label: 'Documents' }];
 
   /**

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -131,7 +131,8 @@ export class RecordSearchComponent implements OnInit, OnChanges {
     pagination?: {
       boundaryLinks?: boolean,
       maxSize?: number
-    }
+    },
+    form?: object
   }[] = [{ key: 'documents', label: 'Documents' }];
 
   /**


### PR DESCRIPTION
* Provides a way to populate select options with a custom logic specified in route configuration.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>