### PR TITLE
editor: fix toggle wrapper behavior

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/toggle-wrapper/toggle-wrappers.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/toggle-wrapper/toggle-wrappers.component.ts
@@ -27,7 +27,14 @@ export class ToggleWrapperComponent extends FieldWrapper implements OnInit {
     if (this.to['toggle-switch']) {
       this.tsOptions = {...this.tsOptions, ...this.to['toggle-switch']};
     }
-    this.tsOptions.enabled = !isEmpty(removeEmptyValues(this.model));
+    /* When wrapper is initialize, we should enable the toggle if the model already contains some data.
+     * But, on init, the model isn't yet populated with data ; so we can't just check the model.
+     * The least worst solution is to subscribe to `valueChanges` observable and check the model when we receive a response
+     * Note: for a 'CustomField', it's better to implement `FormlyExtension` and use the `onPopulate` method
+     */
+    this.formControl.valueChanges.subscribe(
+      () => this.tsOptions.enabled = !isEmpty(removeEmptyValues(this.model))
+    );
   }
 
   toggle(event: any) {


### PR DESCRIPTION
When toggle wraps some fields containing data model, the toggle should be enable but it isn't.
This fix solved this problem.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
