### PR TITLE
search: add nested aggregations support

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -178,6 +178,8 @@ const routes: Routes = [
           canRead,
           aggregations,
           adminMode: adminModeCan,
+          aggregationsBucketSize: 8,
+          aggregationsExpand: ['language'],
           formFieldMap,
           listHeaders: {
             'Content-Type': 'application/rero+json'

--- a/projects/ng-core-tester/src/app/home/home.component.ts
+++ b/projects/ng-core-tester/src/app/home/home.component.ts
@@ -16,10 +16,9 @@
 */
 
 import { Component } from '@angular/core';
-
-import { DialogService, ApiService, TranslateLanguageService } from '@rero/ng-core';
-import { DocumentComponent } from '../record/document/document.component';
+import { ApiService, DialogService, RecordSearchService, TranslateLanguageService } from '@rero/ng-core';
 import { ToastrService } from 'ngx-toastr';
+import { DocumentComponent } from '../record/document/document.component';
 
 @Component({
   selector: 'app-home',
@@ -65,7 +64,8 @@ export class HomeComponent {
     private dialogService: DialogService,
     private apiService: ApiService,
     private translateLanguageService: TranslateLanguageService,
-    private toastrService: ToastrService
+    private toastrService: ToastrService,
+    private _recordSearchService: RecordSearchService
   ) {
     this.apiData = {
       relative: this.apiService.getEndpointByType('documents'),
@@ -73,6 +73,9 @@ export class HomeComponent {
     };
 
     this.testLanguageTranslation = this.translateLanguageService.translate('fr', 'fr');
+
+    // Initializes aggregations filters to launch the first search.
+    this._recordSearchService.setAggregationsFilters([]);
   }
 
   showDialog() {

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -107,7 +107,7 @@ export class EditorComponent implements OnInit, OnDestroy {
    * Component initialisation
    */
   ngOnInit() {
-    combineLatest(this.route.params, this.route.queryParams)
+    combineLatest([this.route.params, this.route.queryParams])
       .pipe(map(results => ({ params: results[0], query: results[1] })))
       .subscribe(results => {
         const params = results.params;

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -52,6 +52,7 @@ import { MultiSchemaTypeComponent } from './editor/multischema/multischema.compo
 import { DatepickerTypeComponent } from './editor/type/datepicker-type.component';
 import {ToggleWrapperComponent} from './editor/toggle-wrapper/toggle-wrappers.component';
 import { hooksFormlyExtension } from './editor/extensions';
+import { BucketsComponent } from './search/aggregation/buckets/buckets.component';
 
 
 @NgModule({
@@ -75,7 +76,8 @@ import { hooksFormlyExtension } from './editor/extensions';
     SwitchComponent,
     MultiSchemaTypeComponent,
     DatepickerTypeComponent,
-    ToggleWrapperComponent
+    ToggleWrapperComponent,
+    BucketsComponent
   ],
   imports: [
     CoreModule,

--- a/projects/rero/ng-core/src/lib/record/record.service.ts
+++ b/projects/rero/ng-core/src/lib/record/record.service.ts
@@ -88,7 +88,7 @@ export class RecordService {
    * @param query - string, keyword to search for
    * @param page - number, return records corresponding to this page
    * @param itemsPerPage - number, number of records to return
-   * @param aggFilters - number, option list of filters
+   * @param aggregationsFilters - number, option list of filters
    * @param sort - parameter for sorting records (eg. 'mostrecent' or '-mostrecent')
    */
   public getRecords(
@@ -96,7 +96,7 @@ export class RecordService {
     query: string = '',
     page = 1,
     itemsPerPage = RecordService.DEFAULT_REST_RESULTS_SIZE,
-    aggFilters: any[] = [],
+    aggregationsFilters: any[] = [],
     preFilters: object = {},
     headers: any = null,
     sort: string = null
@@ -110,7 +110,7 @@ export class RecordService {
       httpParams = httpParams.append('sort', sort);
     }
 
-    aggFilters.forEach((filter) => {
+    aggregationsFilters.forEach((filter) => {
       filter.values.forEach((value: string) => {
         httpParams = httpParams.append(filter.key, value);
       });

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
@@ -24,21 +24,11 @@
   </div>
   <div class="collapse" [class.show]="showAggregation()">
     <div class="card-body">
-      <ul class="list-unstyled m-0">
-        <li class="form-check" *ngFor="let bucket of aggregation.value.buckets|slice:0:bucketSize">
-          <input class="form-check-input" type="checkbox" [checked]="isSelected(bucket.key)"
-            (click)="updateFilter(bucket.key) ">
-          <label class="form-check-label">
-            <span *ngIf="bucket.name">{{ bucket.name }}</span>
-            <span *ngIf="!bucket.name && aggregation.key != 'language'">{{ bucket.key | translate }}</span>
-            <span *ngIf="!bucket.name && aggregation.key == 'language'">{{ bucket.key | translateLanguage:language }}</span> ({{ bucket.doc_count }})
-          </label>
-        </li>
-      </ul>
-      <div *ngIf="displayMoreAndLessLink()">
-        <button class="btn btn-link ml-2" *ngIf="moreMode" (click)="setMoreMode(false)" translate>more…</button>
-        <button class="btn btn-link ml-2" *ngIf="!moreMode" (click)="setMoreMode(true)" translate>less…</button>
-      </div>
+      <ng-core-record-search-aggregation-buckets
+      [buckets]="aggregation.value.buckets"
+      [aggregationKey]="aggregation.key"
+      [size]="aggregation.bucketSize"
+      ></ng-core-record-search-aggregation-buckets>
     </div>
   </div>
 </div>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.spec.ts
@@ -15,11 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslateModule, TranslateLoader, TranslateFakeLoader } from '@ngx-translate/core';
-
-import { RecordSearchAggregationComponent } from './aggregation.component';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { UpperCaseFirstPipe } from '../../../pipe/ucfirst.pipe';
 import { TranslateLanguagePipe } from '../../../translate/translate-language.pipe';
+import { RecordSearchService } from '../record-search.service';
+import { RecordSearchAggregationComponent } from './aggregation.component';
+import { BucketsComponent } from './buckets/buckets.component';
 
 describe('RecordSearchAggregationComponent', () => {
   let component: RecordSearchAggregationComponent;
@@ -30,13 +31,15 @@ describe('RecordSearchAggregationComponent', () => {
       declarations: [
         RecordSearchAggregationComponent,
         UpperCaseFirstPipe,
-        TranslateLanguagePipe
+        TranslateLanguagePipe,
+        BucketsComponent
       ],
       imports: [
         TranslateModule.forRoot({
           loader: { provide: TranslateLoader, useClass: TranslateFakeLoader }
         })
-      ]
+      ],
+      providers: [RecordSearchService]
     })
       .compileComponents();
   }));
@@ -60,52 +63,10 @@ describe('RecordSearchAggregationComponent', () => {
         ]
       }
     };
-    component.selectedValues = ['Filippini, Massimo'];
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should return true if value is selected', () => {
-    expect(component.isSelected('Filippini, Massimo')).toBe(true);
-  });
-
-  it('should show aggregation filter', () => {
-    expect(component.showAggregation()).toBe(true);
-
-    component.expand = false;
-    expect(component.showAggregation()).toBe(true);
-  });
-
-  it('should add value to selected filters', () => {
-    component.updateFilter('Botturi, Luca');
-    expect(component.selectedValues.includes('Botturi, Luca')).toBe(true);
-  });
-
-  it('should remove value from selected filters', () => {
-    component.updateFilter('Filippini, Massimo');
-    expect(component.selectedValues.includes('Filippini, Massimo')).toBe(false);
-  });
-
-  it('should return a correct bucket size', () => {
-    component.aggregation.bucketSize = null;
-    expect(component.bucketSize).toBe(2);
-
-    component.aggregation.bucketSize = 1;
-    expect(component.bucketSize).toBe(1);
-
-    component.moreMode = false;
-    component.aggregation.bucketSize = 1;
-    expect(component.bucketSize).toBe(2);
-  });
-
-  it('should display link', () => {
-    component.aggregation.bucketSize = 1;
-    expect(component.displayMoreAndLessLink).toBeTruthy();
-
-    component.aggregation.bucketSize = 5;
-    expect(component.displayMoreAndLessLink).toBeTruthy();
   });
 });

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
@@ -14,8 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'ng-core-record-search-aggregation',
@@ -26,107 +25,39 @@ export class RecordSearchAggregationComponent {
    * Aggregation data
    */
   @Input()
-  public aggregation: { key: string, bucketSize: any, value: { buckets: {}[] } };
+  aggregation: { key: string, bucketSize: any, value: { buckets: Array<any> } };
 
   /**
-   * Selected value for filter
+   * Current selected values
    */
   @Input()
-  public selectedValues: string[] = [];
+  aggregationsFilters = [];
 
   /**
-   * Show or hide filter items
+   * If true, by default buckets are displayed.
    */
   @Input()
-  public expand = true;
+  expand = true;
 
   /**
-   * Emit event to parent when a value is clicked
+   * Returns aggregations filters corresponding to the aggregation key.
+   * @return List of aggregation filters
    */
-  @Output()
-  public updateAggregationFilter = new EventEmitter<{ term: string, values: string[] }>();
+  get aggregationFilters(): Array<string> {
+    const aggregationFilters = this.aggregationsFilters.find((item: any) => item.key === this.aggregation.key);
 
-  /**
-   * More and less on aggregation content (facet)
-   */
-  moreMode = true;
-
-  /**
-   * Constructor
-   * @param translate TranslateService
-   */
-  constructor(private translate: TranslateService) {}
-
-  /**
-   * Interface language
-   */
-  get language() {
-    return this.translate.currentLang;
-  }
-
-  /**
-   * Check if a value is already registered in filters.
-   * @param value - string, filter value
-   */
-  isSelected(value: string) {
-    return this.selectedValues.includes(value);
-  }
-
-  /**
-   * Update selected values with given value and emit event to parent
-   * @param value - string, filter value
-   */
-  updateFilter(value: string) {
-    if (this.isSelected(value)) {
-      this.selectedValues = this.selectedValues.filter(selectedValue => selectedValue !== value);
-    } else {
-      this.selectedValues.push(value);
+    if (aggregationFilters === undefined) {
+      return [];
     }
 
-    this.updateAggregationFilter.emit({ term: this.aggregation.key, values: this.selectedValues });
+    return aggregationFilters.values;
   }
 
   /**
-   * Return bucket size
+   * Display buckets for the aggregation or not.
+   * @return Boolean
    */
-  get bucketSize() {
-    const aggregationBucketSize = this.aggregation.value.buckets.length;
-    if (this.aggregation.bucketSize === null) {
-      return aggregationBucketSize;
-    } else {
-      if (this.moreMode) {
-        return this.aggregation.bucketSize;
-      } else {
-        return aggregationBucketSize;
-      }
-    }
-  }
-
-  /**
-   * Show filter values
-   * @return boolean
-   */
-  showAggregation() {
-    return this.expand || this.selectedValues.length > 0;
-  }
-
-  /**
-   * Display more or less link
-   * @return boolean
-   */
-  displayMoreAndLessLink(): boolean {
-    if (this.aggregation.bucketSize === null) {
-      return false;
-    }
-    return this.aggregation.value.buckets.length > this.aggregation.bucketSize;
-  }
-
-  /**
-   * Set More mode
-   * @param state - boolean
-   * @return void
-   */
-  setMoreMode(state: boolean) {
-    this.moreMode = state;
+  showAggregation(): boolean {
+    return this.expand || this.aggregationFilters.length > 0;
   }
 }

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
@@ -1,0 +1,36 @@
+<!--
+  Invenio angular core
+  Copyright (C) 2019 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<ul *ngIf="buckets" class="list-unstyled m-0">
+  <li class="form-check" *ngFor="let bucket of buckets|slice:0:bucketSize">
+    <input class="form-check-input" type="checkbox" [checked]="isSelected(bucket.key)"
+      (click)="updateFilter(bucket)">
+    <label class="form-check-label">
+      {{ getBucketName(bucket) }} ({{ bucket.doc_count }})
+    </label>
+    <ng-container *ngIf="isSelected(bucket.key)">
+      <ng-core-record-search-aggregation-buckets
+      *ngFor="let aggregation of bucketChildren(bucket)"
+      [buckets]="aggregation.buckets"
+      [aggregationKey]="aggregation.key"
+      ></ng-core-record-search-aggregation-buckets>
+    </ng-container>
+  </li>
+</ul>
+<div *ngIf="displayMoreAndLessLink()">
+  <button class="btn btn-link ml-2"
+    (click)="moreMode = !moreMode">{{ (moreMode ? 'more…' : 'less…') | translate }}</button>
+</div>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.spec.ts
@@ -1,0 +1,46 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateLanguagePipe } from '../../../../translate/translate-language.pipe';
+import { RecordSearchService } from '../../record-search.service';
+import { BucketsComponent } from './buckets.component';
+
+describe('BucketsComponent', () => {
+  let component: BucketsComponent;
+  let fixture: ComponentFixture<BucketsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        BucketsComponent,
+        TranslateLanguagePipe
+      ],
+      imports: [
+        TranslateModule.forRoot({
+          loader: { provide: TranslateLoader, useClass: TranslateFakeLoader }
+        })
+      ],
+      providers: [RecordSearchService]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BucketsComponent);
+    component = fixture.componentInstance;
+    component.buckets = [
+      {
+        doc_count: 30,
+        key: 'Filippini, Massimo'
+      },
+      {
+        doc_count: 9,
+        key: 'Botturi, Luca'
+      }
+    ];
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
@@ -1,0 +1,212 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
+import { AggregationsFilter, RecordSearchService } from '../../record-search.service';
+import { TranslateLanguageService } from '../../../../translate/translate-language.service';
+
+@Component({
+  selector: 'ng-core-record-search-aggregation-buckets',
+  templateUrl: './buckets.component.html'
+})
+export class BucketsComponent implements OnInit, OnDestroy {
+  /**
+   * Buckets list for aggregation
+   */
+  @Input()
+  buckets: Array<any>;
+
+  /**
+   * Aggregation key
+   */
+  @Input()
+  aggregationKey: string;
+
+  /**
+   * Bucket size, if not null, reduce displayed items to this size.
+   */
+  @Input()
+  size: number;
+
+  /**
+   * More and less on aggregation content (facet)
+   */
+  moreMode = true;
+
+  /**
+   * Current selected values for the aggregation
+   */
+  aggregationsFilters: Array<AggregationsFilter> = [];
+
+  /**
+   * Subscription to aggregationsFilters observable
+   */
+  private _aggregationsFiltersSubscription: Subscription;
+
+  /**
+   * Constructor
+   * @param translate Translate service
+   * @param _recordSearchService Record search service
+   */
+  constructor(
+    private translate: TranslateService,
+    private _recordSearchService: RecordSearchService,
+    private _translateLanguage: TranslateLanguageService
+  ) { }
+
+  /**
+   * Component initialization method, which subscribe to the observable of
+   * aggregations filters  for getting the aggregations filters each time
+   * they will change.
+   */
+  ngOnInit() {
+    this._aggregationsFiltersSubscription = this._recordSearchService.aggregationsFilters.subscribe(
+      (aggregationsFilters: Array<AggregationsFilter>) => {
+        if (aggregationsFilters !== null) {
+        this.aggregationsFilters = aggregationsFilters;
+      }
+      }
+    );
+  }
+
+  /**
+   * Component destruction.
+   * Unsubscribes from the observable of aggregations filters.
+   */
+  ngOnDestroy() {
+    this._aggregationsFiltersSubscription.unsubscribe();
+  }
+
+  /**
+   * Returns selected filters for the aggregation key.
+   * @return List of selected filters
+   */
+  get aggregationFilters(): Array<string> {
+    const aggregationFilters = this.aggregationsFilters.find((item: AggregationsFilter) => item.key === this.aggregationKey);
+    if (aggregationFilters === undefined) {
+      return [];
+    }
+    return aggregationFilters.values;
+  }
+
+  /**
+   * Get current language
+   * @return Current language
+   */
+  get language(): string {
+    return this.translate.currentLang;
+  }
+
+  /**
+   * Return bucket size
+   * @return Bucket size
+   */
+  get bucketSize(): number {
+    const size = this.buckets.length;
+
+    if (this.size === null || this.moreMode === false) {
+      return size;
+    }
+
+    return this.size;
+  }
+
+  /**
+   * Check if a value is present in selected filters.
+   * @param value - string, filter value
+   * @return true if the value is present in the array.
+   */
+  isSelected(value: string): boolean {
+    return this.aggregationFilters.includes(value);
+  }
+
+  /**
+   * Update selected filters by adding or removing the given value and push
+   * values to service.
+   * @param value - string, filter value
+   */
+  updateFilter(bucket: any) {
+    const index = this.aggregationsFilters.findIndex((item: any) => {
+      return item.key === this.aggregationKey;
+    });
+
+    if (index === -1) {
+      // No filters exist for the aggregation.
+      this._recordSearchService.updateAggregationFilter(this.aggregationKey, [bucket.key]);
+    } else {
+      if (!this.aggregationsFilters[index].values.includes(bucket.key)) {
+        // Bucket value is not yet selected, we add value to selected values.
+        this.aggregationsFilters[index].values.push(bucket.key);
+        this._recordSearchService.updateAggregationFilter(this.aggregationKey, this.aggregationsFilters[index].values);
+      } else {
+        // Removes value from selected values and all children selected values.
+        this._recordSearchService.removeAggregationFilter(this.aggregationKey, bucket);
+      }
+    }
+  }
+
+  /**
+   * Get children buckets
+   * @param bucket: parent bucket
+   * @return Bucket children list of given bucket
+   */
+  bucketChildren(bucket: any): Array<any> {
+    const children = [];
+    for (const k in bucket) {
+      if (bucket[k].buckets) {
+        children.push({
+          key: k,
+          buckets: bucket[k].buckets
+        });
+      }
+    }
+    return children;
+  }
+
+  /**
+   * Display more or less link
+   * @return Boolean
+   */
+  displayMoreAndLessLink(): boolean {
+    if (this.size === null) {
+      return false;
+    }
+    return this.buckets.length > this.size;
+  }
+
+  /**
+   * Return the name displayed for the bucket.
+   * @param bucket Bucket to get the name from.
+   * @return Displayed name of the bucket.
+   */
+  getBucketName(bucket: any): string {
+    // If a name is provided, we take directly that value.
+    if (bucket.name) {
+      return bucket.name;
+    }
+
+    // For language aggregation, we transform language code to human readable
+    // language.
+    if (this.aggregationKey === 'language') {
+      return this._translateLanguage.translate(bucket.key, this.language);
+    }
+
+    // Simply translate the bucket key.
+    return this.translate.instant(bucket.key);
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.html
@@ -16,6 +16,6 @@
 -->
 
 <ng-core-record-search [adminMode]="adminMode" [currentType]="currentType" [types]="types" [detailUrl]="detailUrl"
-    [showSearchInput]="showSearchInput" [aggFilters]="aggFilters" [q]="q" [page]="page" [size]="size" [sort]="sort" [inRouting]="true"
-    (parametersChanged)="updateUrl($event)">
+  [showSearchInput]="showSearchInput" [q]="q" [page]="page" [size]="size"
+  [sort]="sort" (parametersChanged)="updateUrl($event)">
 </ng-core-record-search>

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -80,9 +80,8 @@
         <div *ngFor="let item of aggregations">
           <ng-core-record-search-aggregation
             [aggregation]="item"
-            [selectedValues]="getFilterSelectedValues(item.key)"
+            [aggregationsFilters]="aggregationsFilters"
             [expand]="expandFacet(item.key)"
-            (updateAggregationFilter)="updateAggregationFilter($event)"
           >
           </ng-core-record-search-aggregation>
         </div>
@@ -96,9 +95,8 @@
               [type]="currentType"
               [itemViewComponent]="getResultItemComponentView()"
               [canUpdate$]="canUpdateRecord$(record)"
-              [inRouting]="inRouting"
               [canDelete$]="canDeleteRecord$(record)"
-              [detailUrl$]="resolveDetailUrl(record)"
+              [detailUrl$]="resolveDetailUrl$(record)"
               (deletedRecord)="deleteRecord($event)"
             >
             </ng-core-record-search-result>
@@ -111,7 +109,7 @@
           [maxSize]="paginationMaxSize"
           [boundaryLinks]="paginationBoundaryLinks"
           class="justify-content-center mt-5"
-          *ngIf="showPagination()"
+          *ngIf="showPagination"
           previousText="&lsaquo;"
           nextText="&rsaquo;"
           firstText="&laquo;"

--- a/projects/rero/ng-core/src/lib/record/search/record-search.service.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.service.spec.ts
@@ -1,0 +1,13 @@
+import { TestBed } from '@angular/core/testing';
+import { RecordSearchService } from './record-search.service';
+
+describe('RecordSearchService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [RecordSearchService]
+  }));
+
+  it('should be created', () => {
+    const service: RecordSearchService = TestBed.get(RecordSearchService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
@@ -1,0 +1,154 @@
+import { Injectable } from '@angular/core';
+import { cloneDeep } from 'lodash-es';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { first, map } from 'rxjs/operators';
+
+export interface AggregationsFilter {
+  key: string;
+  values: Array<any>;
+}
+
+@Injectable(
+  {
+    providedIn: 'root'
+  }
+)
+export class RecordSearchService {
+  /** Aggregations filters array */
+  private _aggregationsFilters: Array<AggregationsFilter> = null;
+
+  /** Aggregations filters subject */
+  private _aggregationsFiltersSubject: BehaviorSubject<Array<AggregationsFilter>>;
+
+  /**
+   * Constructor, initialize aggregations filters subject.
+   */
+  constructor() {
+    this._aggregationsFiltersSubject = new BehaviorSubject(this._aggregationsFilters);
+  }
+
+  /**
+   * Returns an observable which emits aggregations filters.
+   */
+  get aggregationsFilters(): Observable<Array<AggregationsFilter>> {
+    return this._aggregationsFiltersSubject.asObservable();
+  }
+
+  /**
+   * Set all aggregations filters and emit the list.
+   * @param aggregationsFilters List of aggregations filters
+   */
+  setAggregationsFilters(aggregationsFilters: Array<AggregationsFilter>) {
+    // TODO: If the filter is in a child bucket, checks if all parents are
+    // selected, too. If not, adds all parents filters.
+
+    if (JSON.stringify(this._aggregationsFilters) !== JSON.stringify(aggregationsFilters)) {
+      // Filters are deep copied on assigning and sending, to avoid changes
+      // outside the service on the local value.
+      this._aggregationsFilters = cloneDeep(aggregationsFilters);
+      this._aggregationsFiltersSubject.next(cloneDeep(this._aggregationsFilters));
+    }
+  }
+
+  /**
+   * Stores selected values for an aggregation or removes it if values are empty.
+   * @param term Term (aggregation key)
+   * @param values Selected values
+   */
+  updateAggregationFilter(term: string, values: string[]) {
+    const index = this._aggregationsFilters.findIndex(item => item.key === term);
+
+    if (values.length === 0) {
+      // no more items selected, remove filter
+      this._aggregationsFilters.splice(index, 1);
+    } else {
+      // In both cases values are affected with destructuring assignment, to
+      // avoid values to be modified outside the service, as array are assigned
+      // by reference.
+      if (index !== -1) {
+        // update existing filter
+        this._aggregationsFilters[index] = { key: term, values: [...values] };
+      } else {
+        // add new filter
+        this._aggregationsFilters.push({ key: term, values: [...values] });
+      }
+    }
+
+    this._aggregationsFiltersSubject.next(cloneDeep(this._aggregationsFilters));
+  }
+
+  /**
+   * Get filters of an aggregation
+   * @param key Aggregation key
+   */
+  getAggregationFilters(key: string): Observable<Array<string>> {
+    return this._aggregationsFiltersSubject.pipe(
+      first(),
+      map((aggregationsFilters: Array<AggregationsFilter>) => {
+        const index = aggregationsFilters.findIndex(item => item.key === key);
+        return index === -1 ? [] : aggregationsFilters[index].values;
+      })
+    );
+  }
+
+  /**
+   * Removes the given value from selected filters and removes all children
+   * selected values, too.
+   * @param key Aggregation key
+   * @param bucket Bucket containing the value to remove
+   */
+  removeAggregationFilter(key: string, bucket: any) {
+    let aggregationsFilters = cloneDeep(this._aggregationsFilters);
+
+    const index = aggregationsFilters.findIndex((item: any) => {
+      return item.key === key;
+    });
+
+    let values = aggregationsFilters[index].values;
+
+    // Remove selected value
+    values = values.filter((selectedValue: string) => {
+      return selectedValue !== bucket.key;
+    });
+
+    if (values.length === 0) {
+      // No more selected values, remove key from aggregations filters.
+      aggregationsFilters.splice(index, 1);
+    } else {
+      // re-assign filtered values
+      aggregationsFilters[index].values = [...values];
+    }
+
+    // List of children keys to remove
+    const keysToRemove = this.getKeysToRemove(bucket);
+
+    // Remove all aggregations filters corresponding to children keys.
+    aggregationsFilters = aggregationsFilters.filter((item: AggregationsFilter) => {
+      return (!keysToRemove.includes(item.key));
+    });
+
+    // Update selected aggregations filters
+    this.setAggregationsFilters(aggregationsFilters);
+  }
+
+  /**
+   * Recursive method which collects all children aggregations keys to remove.
+   * @param bucket Current bucket to check
+   * @return List of keys to remove
+   */
+  private getKeysToRemove(bucket: any): Array<string> {
+    let keys = [];
+
+    for (const k in bucket) {
+      if (bucket[k].buckets) {
+        keys.push(k);
+
+        bucket[k].buckets.forEach((childBucket: any) => {
+          keys = [...keys, ...this.getKeysToRemove(childBucket)];
+        });
+      }
+    }
+
+    return keys;
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
@@ -17,7 +17,7 @@
 
 <div class="float-right ml-5 mb-2" *ngIf="adminMode.can">
     <a href class="btn btn-link p-0 ml-2" [title]="'Edit'|translate" routerLink="edit/{{ record.metadata.pid }}"
-        *ngIf="inRouting && updateStatus && updateStatus.can">
+        *ngIf="updateStatus && updateStatus.can">
         <i class="fa fa-pencil"></i>
     </a>
     <span class="ml-2" *ngIf="deleteStatus">

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.ts
@@ -94,12 +94,6 @@ export class RecordSearchResultComponent implements OnInit {
   aggregations: Array<object>;
 
   /**
-   * Indicates if the component is included in angular routes
-   */
-  @Input()
-  inRouting = false;
-
-  /**
    * Observable emitting current value of record URL.
    */
   @Input()

--- a/projects/rero/ng-core/src/lib/widget/menu/menu.component.html
+++ b/projects/rero/ng-core/src/lib/widget/menu/menu.component.html
@@ -20,7 +20,7 @@
     [routerLinkActive]="item.hasOwnProperty('cssActiveClass') ? item.cssActiveClass : 'active'"
     [ngClass]="itemClass(item)"
     [ngSwitch]="itemType(item)">
-      <a *ngSwitchCase="'routerLink'" [routerLink]="item.routerLink"
+      <a *ngSwitchCase="'routerLink'" [routerLink]="item.routerLink" [queryParams]="item.queryParams ? item.queryParams : {}"
       [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'nav-link'"
       ><i *ngIf="item.iconCssClass" [ngClass]="item.iconCssClass" aria-hidden="true"></i> {{ item.name|translate }}</a>
 
@@ -41,7 +41,7 @@
         </a>
         <div *dropdownMenu class="dropdown-menu" role="menu" [ngClass]="menu.hasOwnProperty('dropdownMenuCssClass') ? menu.dropdownMenuCssClass : ''">
           <ng-container *ngFor="let subItem of item.entries | callbackArrayFilter: isItemMenuVisible" [ngSwitch]="itemType(subItem)">
-            <a *ngSwitchCase="'routerLink'" [routerLink]="subItem.routerLink"
+            <a *ngSwitchCase="'routerLink'" [routerLink]="subItem.routerLink" [queryParams]="subItem.queryParams ? subItem.queryParams : {}"
             [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'dropdown-item'"
             ><i *ngIf="subItem.iconCssClass" [ngClass]="subItem.iconCssClass" aria-hidden="true"></i> {{ subItem.name|translate }}</a>
 

--- a/projects/rero/ng-core/src/public-api.ts
+++ b/projects/rero/ng-core/src/public-api.ts
@@ -22,6 +22,7 @@ export * from './lib/dialog/dialog.service';
 export * from './lib/api/api.service';
 export * from './lib/record/record.service';
 export * from './lib/record/record-ui.service';
+export * from './lib/record/search/record-search.service';
 export * from './lib/record/search/result/item/result-item';
 export * from './lib/record/record.module';
 export * from './lib/record/search/record-search-page.component';


### PR DESCRIPTION
* Adds nested aggregations support.
* Refactors RecordSearchComponent.
* Unsubscribes from observables when components are destroyed.
* Creates a RecordSearchService for handling aggregations filters.
* Adapts menu component in order to include query parameters.
* Sets aggregations buckets size to 8 in tester application.
* Fixes "combineLatest" RxJS function deprecation warnings.
* Exports RecordSearchService in public-api to use it outside ng-core.
* Initializes filters to launch first search on homepage.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>