### PR TITLE
editor: fix missing stars for required fields

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.html
@@ -16,20 +16,17 @@
 -->
 
 <!-- array title only if the array is empty -->
-<label *ngIf="to.label && formControl && formControl.length === 0">
+<label *ngIf="to.label && to.hideLabel !== true && formControl && formControl.length === 0" [attr.for]="id">
   <!-- add button only if the max is not reached -->
   <a *ngIf="canAdd()" (click)="add(0)" class="btn btn-link btn-sm">
     <i class="fa fa-plus"></i>
   </a>
   <span [tooltip]="to.description">{{ to.label }}</span>
+  <span *ngIf="to.required && to.hideRequiredMarker !== true">*</span>
 </label>
 
 <!--  validation error message -->
-<div
-  class="alert alert-danger"
-  role="alert"
-  *ngIf="showError && formControl.errors"
->
+<div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
   <formly-validation-message [field]="field"></formly-validation-message>
 </div>
 
@@ -38,78 +35,48 @@
 <ng-container *ngFor="let f of field.fieldGroup; let i = index">
   <!-- put title with menu section for item object -->
   <div *ngIf="isChildrenObject">
-    <ng-container
-      *ngTemplateOutlet="hasMenu(f) ? menu : title; context: { f: f, i: i }"
-    >
+    <ng-container *ngTemplateOutlet="hasMenu(f) ? menu : title; context: { f: f, i: i }">
     </ng-container>
 
     <!--  object validation error message -->
-    <div
-      class="alert alert-danger"
-      role="alert"
-      *ngIf="f.options.showError && f.formControl.errors"
-    >
+    <div class="alert alert-danger" role="alert" *ngIf="f.options.showError && f.formControl.errors">
       <formly-validation-message [field]="f"></formly-validation-message>
     </div>
   </div>
 
   <!-- all kind of item -->
-  <div
-    class="d-flex mb-2"
-    [ngClass]="{ 'pl-2 border-left': isChildrenObject }"
-  >
+  <div class="d-flex mb-2" [ngClass]="{ 'pl-2 border-left': isChildrenObject }">
     <!-- add button -->
-    <ng-container
-      *ngTemplateOutlet="addButton; context: { i: i }"
-    ></ng-container>
-
+    <ng-container *ngTemplateOutlet="addButton; context: { i: i }"></ng-container>
     <!-- item itself -->
     <div class="flex-grow-1">
+      <!-- add label for array of arrays -->
+      <span *ngIf="isChildrenArray">{{f.templateOptions.label}}</span>
       <formly-field [field]="f"></formly-field>
     </div>
     <!-- remove button -->
-    <ng-container
-      *ngTemplateOutlet="removeButton; context: { i: i }"
-    ></ng-container>
+    <ng-container *ngTemplateOutlet="removeButton; context: { i: i }"></ng-container>
   </div>
 </ng-container>
 
 <!-- TEMPLATES -->
 <!-- dropdown menu -->
 <ng-template #menu let-f="f" let-i="i">
-  <ng-core-editor-dropdown-label-editor
-    [field]="f"
-    [canAdd]="canAdd()"
-    (addClicked)="add(i + 1)"
-  >
+  <ng-core-editor-dropdown-label-editor [field]="f" [canAdd]="canAdd()" (addClicked)="add(i + 1)">
     <ng-container *ngIf="f.type === 'object'">
-      <ng-container
-        *ngFor="
+      <ng-container *ngFor="
           let fChildren of hiddenFieldGroup(f.fieldGroup);
           let first = first;
           let last = last
-        "
-      >
+        ">
         <h6 *ngIf="first" class="dropdown-header" translate>Add fields</h6>
-        <button
-          class="dropdown-item"
-          (click)="fChildren.hide = false"
-          type="button"
-        >
+        <button class="dropdown-item" (click)="fChildren.hide = false" type="button">
           {{ fChildren.templateOptions.label }}
         </button>
-        <div
-          *ngIf="last && f.templateOptions.helpURL"
-          class="dropdown-divider"
-        ></div>
+        <div *ngIf="last && f.templateOptions.helpURL" class="dropdown-divider"></div>
       </ng-container>
     </ng-container>
-    <a
-      *ngIf="f.templateOptions.helpURL"
-      class="dropdown-item"
-      [href]="f.templateOptions.helpURL"
-      translate
-    >
+    <a *ngIf="f.templateOptions.helpURL" class="dropdown-item" [href]="f.templateOptions.helpURL" translate>
       Help
     </a>
   </ng-core-editor-dropdown-label-editor>
@@ -117,31 +84,26 @@
 
 <!-- section title -->
 <ng-template #title let-f="f" let-i="i">
-  <a *ngIf="canAdd()" (click)="add(i + 1)" class="btn btn-link btn-sm">
-    <i class="fa fa-plus"></i>
-  </a>
-  <span [id]="f.id">{{ f.templateOptions.label }}</span>
+  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id">
+    <a *ngIf="canAdd()" (click)="add(i + 1)" class="btn btn-link btn-sm">
+      <i class="fa fa-plus"></i>
+    </a>
+    {{ f.templateOptions.label }}
+    <span *ngIf="f.templateOptions.required && f.templateOptions.hideRequiredMarker !== true">*</span>
+  </label>
 </ng-template>
 
 <!-- add button -->
 <ng-template #addButton let-i="i">
-  <a
-    *ngIf="!isChildrenObject && canAdd()"
-    (click)="add(i + 1)"
-    class="btn btn-link btn-sm"
-  >
+  <a *ngIf="!isChildrenObject && canAdd()" (click)="add(i + 1)" class="btn btn-link btn-sm">
     <i class="fa fa-plus"></i>
   </a>
 </ng-template>
 
 <!-- tash button -->
 <ng-template #removeButton let-i="i">
-  <button
-    (click)="remove(i)"
-    *ngIf="canRemove()"
-    class="btn btn-outline-secondary ml-1 btn-sm"
-    [ngClass]="{ 'mb-2': isChildrenObject }"
-  >
+  <button (click)="remove(i)" *ngIf="canRemove()" class="btn btn-outline-secondary ml-1 btn-sm"
+    [ngClass]="{ 'mb-2': isChildrenObject }">
     <i class="fa fa-trash"></i>
   </button>
 </ng-template>

--- a/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.ts
@@ -23,16 +23,41 @@ import { FieldArrayType, FormlyFieldConfig } from '@ngx-formly/core';
   templateUrl: 'array-type.component.html'
 })
 export class ArrayTypeComponent extends FieldArrayType implements OnInit {
-  /**
-   * Are the children of type object?
-   */
+  /** True if children are of type object */
   isChildrenObject = false;
+
+  /** True if the children are of type array */
+  isChildrenArray = false;
 
   /**
    * Component initialization
    */
   ngOnInit() {
     this.isChildrenObject = this.field.fieldArray.type === 'object';
+    this.isChildrenArray = this.field.fieldArray.type === 'array';
+
+    // reset the number of elements in the array when the array id hidden
+    this.field.options.fieldChanges.subscribe(changes => {
+      const minItems = this.field.templateOptions.minItems ? this.field.templateOptions.minItems : 0;
+      if (
+        // hide property has changed
+        changes.type === 'hidden'
+        // transition from visible to hide
+        && (changes.value === true)
+        // the changes concern the current field
+        && (this.field.id === changes.field.id)
+      ) {
+        // number of elements to remove
+        const numberOfItemsToRemove = this.field.fieldGroup.length - minItems;
+        // remove the extra elements
+        // force removing the elements in the next event loop else this cause errors when removing multiple values
+        setTimeout(() => {
+          for (let i = 0; i < numberOfItemsToRemove; i++) {
+            this.remove(0);
+          }
+        });
+      }
+    });
   }
 
   /**

--- a/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
@@ -76,7 +76,10 @@
 
 <!-- section title -->
 <ng-template #title let-f="f">
-  <span [id]="f.id">{{ f.templateOptions.label }}</span>
+  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id">
+    {{ f.templateOptions.label }}
+    <span *ngIf="f.templateOptions.required && f.templateOptions.hideRequiredMarker !== true">*</span>
+  </label>
 </ng-template>
 
 <!-- trash button -->


### PR DESCRIPTION
* Fixes missing stars after required field titles when the editor is displayed.
* Fixes the number of items after the hiding and showing array fields.
It should be equal to the minimum number of items defined in the JSONSchema.
* Fixes missing title for array of array fields.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-by: Gianni Pante <gianni.pante@rero.ch>

## Why are you opening this PR?

- Implements US: https://tree.taiga.io/project/rero21-reroils/us/1232?milestone=257446

## How to test?

- Deploy with rero-ils: https://github.com/rero/rero-ils/pull/864
- Check that a start is displayed next to the title.
![image](https://user-images.githubusercontent.com/127249/78384965-6a4de980-75db-11ea-9e27-512dd8c5c953.png)

- Check that the Publication statement is displayed correctly (array of array)
![image](https://user-images.githubusercontent.com/127249/78385028-7df95000-75db-11ea-8272-dc0521d1892d.png)

- Take an array element add several values, hide the field, show the field. The field should be as the initial state of the editor (creation).

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [x] Extracted translations?
