### PR TITLE
translations: translate values for enum fields

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/interfaces.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/interfaces.ts
@@ -1,0 +1,25 @@
+/*
+ * Invenio angular core
+ * Copyright (C) 2019 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Interface representing an option in select box.
+ */
+export interface SelectOption {
+  label: string;
+  value: string;
+  group?: string;
+}

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -155,7 +155,9 @@ import { BucketsComponent } from './search/aggregation/buckets/buckets.component
     AutocompleteComponent,
     GetRecordPipe,
     CoreModule,
-    EditorComponent
+    EditorComponent,
+    FormlyModule,
+    FormlyBootstrapModule
   ],
   entryComponents: [
     JsonComponent,

--- a/projects/rero/ng-core/src/lib/translate/translate-language.service.spec.ts
+++ b/projects/rero/ng-core/src/lib/translate/translate-language.service.spec.ts
@@ -15,14 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { TestBed } from '@angular/core/testing';
-
-import { TranslateLanguageService } from './translate-language.service';
 import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { TranslateLanguageService } from './translate-language.service';
 
 describe('TranslateLanguageService', () => {
 
-  const translateServiceSpy = jasmine.createSpyObj('TranslateService', ['currentLang']);
+  const translateServiceSpy = jasmine.createSpyObj('TranslateService', ['currentLang', 'onLangChange']);
   translateServiceSpy.currentLang = 'fr';
+  translateServiceSpy.onLangChange = of(null);
 
   let service: TranslateLanguageService;
 

--- a/projects/rero/ng-core/src/lib/translate/translate-service.ts
+++ b/projects/rero/ng-core/src/lib/translate/translate-service.ts
@@ -14,17 +14,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Inject, Injectable } from '@angular/core';
-import { TranslateService as NgxTranslateService } from '@ngx-translate/core';
-import moment from 'moment';
-import { BsLocaleService, deLocale, enGbLocale,
-         frLocale, itLocale, defineLocale } from 'ngx-bootstrap';
 import { registerLocaleData } from '@angular/common';
 import localeDe from '@angular/common/locales/de';
 import localeEn from '@angular/common/locales/en';
 import localeFr from '@angular/common/locales/fr';
 import localeIt from '@angular/common/locales/it';
+import { Inject, Injectable } from '@angular/core';
+import { TranslateService as NgxTranslateService } from '@ngx-translate/core';
+import moment from 'moment';
+import { BsLocaleService, defineLocale, deLocale, enGbLocale, frLocale, itLocale } from 'ngx-bootstrap';
 import { CoreConfigService } from '../core-config.service';
+import { SelectOption } from '../record/editor/interfaces';
 
 @Injectable({
   providedIn: 'root'
@@ -52,6 +52,17 @@ export class TranslateService {
     return this;
   }
 
+  /**
+   * Return the translation of the given label.
+   * Proxy for "instant" method of the translate service of ngx-translate.
+   * @param key String to translate.
+   * @param interpolateParams Parameters to interpolate.
+   * @return Translated value as string.
+   */
+  translate(key: string | Array<string>, interpolateParams: any = null): string {
+    return this.translateService.instant(key, interpolateParams);
+  }
+
   getBrowserLang() {
     return this.translateService.getBrowserLang();
   }
@@ -60,6 +71,30 @@ export class TranslateService {
     return this.translateService.currentLang
            || this.coreConfigService.defaultLanguage
            || 'en';
+  }
+
+  /**
+   * Return the options for select box, with translations.
+   * @param values Values to populate option with.
+   * @param prefix Prefix for translations.
+   * @param sort If true, sort in alphabetical order after populating options.
+   * @return List of options.
+   */
+  getSelectOptions(values: Array<string>, prefix: string = null, sort = true): Array<SelectOption> {
+    const options = values.map((value: string) => {
+      return {
+        label: this.translateService.instant((prefix || '') + value),
+        value
+      };
+    });
+
+    if (sort === true) {
+      return options.sort((a: SelectOption, b: SelectOption) => {
+        return a.label.localeCompare(b.label);
+      });
+    }
+
+    return options;
   }
 
   private init() {


### PR DESCRIPTION
* Translates values for the "language" field.
* Translates values for others enum fields.
* Exports FormlyModule and FormlyBootstrapModule for reuse in host application.
* Creates an interface representing a select option.

Co-Authored-by: Sébastien Délèze sebastien.deleze@rero.ch