### PR TITLE
document: filter search by organisation

### DIFF
--- a/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.html
+++ b/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.html
@@ -41,8 +41,9 @@
   (typeaheadOnSelect)="typeaheadOnSelect($event)"
   [typeaheadIsFirstItemActive]="false"
   >
-  <input type="hidden" name="size" value="10">
-  <input type="hidden" name="page" value="1">
+  <input type="hidden" *ngFor="let queryParam of extraQueryParams | keyvalue"
+    [name]="queryParam.key"
+    [value]="queryParam.value">
   <div class="input-group-append">
     <button type="submit" (click)="doSearch($event)" [ngClass]="buttonCssClass">
       <i *ngIf="!typeaheadLoading" class="fa fa-search"></i>

--- a/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.ts
+++ b/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.ts
@@ -61,6 +61,9 @@ export class AutocompleteComponent implements OnInit {
   // The maximum length of options items list. The default value is 20.
   @Input() typeaheadOptionsLimit = 10;
 
+  // Additional query parameters
+  @Input() extraQueryParams = { page: '1', size: '10' };
+
   // The current selected suggestion.
   asyncSelected = {
     text: undefined,
@@ -134,7 +137,10 @@ export class AutocompleteComponent implements OnInit {
     if (!this._redirect) {
       if (this.internalRouting) {
         this._router.navigate([this.action], {
-          queryParams: { q: this.asyncSelected.query, page: '1', size: '10' }
+          queryParams: {
+            ...this.extraQueryParams,
+            q: this.asyncSelected.query
+          }
         });
       } else {
         this.form.nativeElement.submit();

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
@@ -23,8 +23,9 @@
     </label>
     <ng-container *ngIf="isSelected(bucket.key)">
       <ng-core-record-search-aggregation-buckets
-      *ngFor="let aggregation of bucketChildren(bucket)"
+      *ngFor="let aggregation of bucketChildren[bucket.key]"
       [buckets]="aggregation.buckets"
+      [size]="aggregation.bucketSize"
       [aggregationKey]="aggregation.key"
       ></ng-core-record-search-aggregation-buckets>
     </ng-container>


### PR DESCRIPTION
* Adds the possibility of giving additional query parameters to filter
search.
* Corrects 'display more' function in nested facets.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

To apply corrections asked by the PO group.
https://tree.taiga.io/project/rero21-reroils/task/1441?kanban-status=1224894

## How to test?

Needs https://github.com/rero/rero-ils-ui/pull/208 and https://github.com/rero/rero-ils/pull/852 + ebooks harvesting.

1. In admin view, do a search of a document. The result should be filtered by user's organisation.
2. Ebooks count should consider organisation filtering too.
1. Children (library) facet should be reduced to 10 items. Click on `more...` to display all of them and on `less...` to hide again.

See https://github.com/rero/rero-ils/pull/852#pullrequestreview-394478067 for detailed description of issues.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
