### PR TITLE
autocomplete: fix suggestions are not displayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10171,9 +10171,9 @@
       }
     },
     "ngx-bootstrap": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-5.3.2.tgz",
-      "integrity": "sha512-gSMf8EXYl99Q3gqkq4RVhoTNSTYHz2Or6Cig2BJRbLJyqk15ZQE5qcq/ldHS8zzx/wgCA3HQeI63t2j2mEU9PA=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-5.5.0.tgz",
+      "integrity": "sha512-BJeghbkKFQl49sg3GIYQyjvwaHn64xFOsinBVD8HWKOVpRJSnuafrjXByGDtfq35jGY4R+7iBLksM1IYLUPshg=="
     },
     "ngx-toastr": {
       "version": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "handlebars": "^4.7.3",
     "lodash-es": "4.17.14",
     "moment": "^2.24.0",
-    "ngx-bootstrap": "~5.3.2",
+    "ngx-bootstrap": "~5.5.0",
     "ngx-toastr": "^10.2.0",
     "rxjs": "^6.5.4",
     "tslib": "^1.9.0",

--- a/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.ts
+++ b/projects/rero/ng-core/src/lib/record/autocomplete/autocomplete.component.ts
@@ -18,7 +18,7 @@ import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TypeaheadMatch } from 'ngx-bootstrap';
 import { combineLatest, Observable, of } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 import { RecordService } from '../record.service';
 
 @Component({
@@ -121,7 +121,7 @@ export class AutocompleteComponent implements OnInit {
         // Runs on every search
         observer.next(this.asyncSelected);
       }).pipe(
-        mergeMap((asyncSelected: any) =>
+        switchMap((asyncSelected: any) =>
           this.getSuggestions(asyncSelected.query)
         )
       );
@@ -132,8 +132,10 @@ export class AutocompleteComponent implements OnInit {
    * Apply search action
    * @param event - Event, DOM event
    */
-  doSearch(event: any) {
-    event.preventDefault();
+  doSearch(event: any = null) {
+    if (event != null) {
+      event.preventDefault();
+    }
     if (!this._redirect) {
       if (this.internalRouting) {
         this._router.navigate([this.action], {
@@ -155,7 +157,7 @@ export class AutocompleteComponent implements OnInit {
   getSuggestions(query: string): Observable<any> {
     // patch non working typeaheadMinLength properties
     if (query.length < this.typeaheadMinLength) {
-      return of(undefined);
+      return of([]);
     }
     const combineGetRecords = [];
     const recordTypesKeys = this.recordTypes.map(recordType => recordType.type);
@@ -210,6 +212,8 @@ export class AutocompleteComponent implements OnInit {
         window.location.href = e.item.href;
       }
       this._redirect = true;
+    } else {
+      this.doSearch();
     }
   }
 }

--- a/projects/rero/ng-core/src/lib/record/record.service.ts
+++ b/projects/rero/ng-core/src/lib/record/record.service.ts
@@ -227,7 +227,7 @@ export class RecordService {
     if (excludePid) {
       query += ` NOT pid:${excludePid}`;
     }
-    return this.getRecords(recordType, query, 1, 0).pipe(
+    return this.getRecords(recordType, query, 1, 1).pipe(
       map((res) => res.hits.total),
       map((total) => (total ? { alreadyTakenMessage: value } : null)),
       debounceTime(1000)


### PR DESCRIPTION
The list of suggestions are sometime not displayed when the server take
few milliseconds to respond. This has been fixed in a new version of the
third party library `ngx-bootstrap`.

Moreover when a document is selected the search should be executed.

* Fixes the display of the suggestion list for unquick server response.
* Executes the search query when a suggestion is clicked.
* Fixes minimal size value for REST API since "invenio-records-rest>1.4.2".
* Fixes console error when a query is removed by keeping backspace key
pressed.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Required by
- https://github.com/rero/rero-ils-ui/pull/253

## Why are you opening this PR?

- To fix: rero/rero-ils#788

## How to test?

- Go to a view containing an autocomplete component.
- Type slowly a query, after 3 chars the list of suggestions should be displayed.
- If you click on any kind of suggestion, the search should be executed without clicking the search button.

## Code review check list

- [x] Commit message template compliance.
- [x] Commit message without typos.
- [x] File names.
- [x] Functions names.
- [x] Functions docstrings.
- [x] Unnecessary commited files?
- [x] Extracted translations?
