### PR TITLE
search input: set focus on search input by default

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -39,6 +39,7 @@
           [searchText]="q"
           [displayLabel]="false"
           (search)="searchByQuery($event)"
+          [focus]="true"
         >
         </ng-core-search-input>
       </div>

--- a/projects/rero/ng-core/src/lib/search-input/search-input.component.html
+++ b/projects/rero/ng-core/src/lib/search-input/search-input.component.html
@@ -16,8 +16,7 @@
 -->
 <label for="search" class="font-weight-bold" *ngIf="displayLabel">{{ placeholder }}</label>
 <div class="input-group px-0">
-  <!-- TODO: remove autofocus -->
-  <input #searchinput autofocus type="text" id="search" class="form-control"
+  <input #searchinput type="text" id="search" class="form-control"
     [attr.placeholder]="!displayLabel && placeholder ? placeholder : null" attr.aria-label="{{ placeholder }}"
     [value]="searchText" (keyup.enter)="doSearch(searchinput.value)">
   <div class="input-group-append">


### PR DESCRIPTION
* Removes 'autofocus' html attribute.
* Sets the focus on search input.
* Closes rero/rero-ils#928.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?
To implement task 1462: https://tree.taiga.io/project/rero21-reroils/task/1462?kanban-status=1224894
To close https://github.com/rero/rero-ils/issues/928

## How to test?

Go to different brief views of professional interface.
Check that the focus is automatically set on the search input.
Go to the document editor.
Check that there is no conflict with the focus in the editor.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
