### PR TITLE
utils : update extractIdOnRef if value is null.

### DIFF
--- a/projects/rero/ng-core/src/lib/utils/utils.ts
+++ b/projects/rero/ng-core/src/lib/utils/utils.ts
@@ -15,8 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 export function extractIdOnRef(ref: string) {
-  const pidRegExp = new RegExp('.*/(.*)$');
-  return pidRegExp.exec(ref)[1];
+  if (ref != null) {
+    const pidRegExp = new RegExp('.*/(.*)$');
+    return pidRegExp.exec(ref)[1];
+  }
+  return null;
 }
 
 export function cleanDictKeys(data: any) {


### PR DESCRIPTION
Sometimes, some '$ref' frm the model are null values (This is the case
for 'restrict_pickup_to' on location schema if no restrict are defined).
In this case, the function 'extractIdOnRef' generates an error and
causes instability in the corresponding resource editor.
This commit resolves this problem.

Co-authored-by : Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
