### PR TITLE
editor: adapt editor according to UX chart

### DIFF
--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.html
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.html
@@ -22,13 +22,13 @@
         {{ 'Edit' | translate }}
     </a>
     <ng-container *ngIf="deleteStatus">
-        <button class="btn btn-sm btn-primary ml-1" [title]="'Delete'|translate"
+        <button class="btn btn-sm btn-outline-danger ml-1" [title]="'Delete'|translate"
             (click)="deleteRecord(record.metadata.pid)" *ngIf="deleteStatus.can; else deleteMessageLink">
             <i class="fa fa-trash"></i>
             {{ 'Delete' | translate }}
         </button>
         <ng-template #deleteMessageLink>
-            <button class="btn btn-sm btn-dark ml-1" [title]="'Delete'|translate"
+            <button class="btn btn-sm btn-outline-danger ml-1 disabled" [title]="'Delete'|translate"
                 (click)="showDeleteMessage(deleteStatus.message)" *ngIf="deleteStatus.message">
                 <i class="fa fa-trash mr-1"></i>{{ 'Delete' | translate }}
             </button>

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -58,20 +58,20 @@
       <div class="mt-4 float-right">
         <!-- submit button -->
         <button
+          type="button"
+          (click)="cancel()"
+          class="btn btn-outline-danger btn-sm mr-1"
+        >
+          <i class="fa fa-times"></i>
+          {{ 'Cancel' | translate }}
+        </button>
+        <button
           type="submit"
           class="btn btn-primary btn-sm"
           [disabled]="!form.valid"
         >
           <i class="fa fa-save"></i>
           {{ 'Save' | translate }}
-        </button>
-        <button
-          type="button"
-          (click)="cancel()"
-          class="btn btn-primary btn-sm ml-1"
-        >
-          <i class="fa fa-times"></i>
-          {{ 'Cancel' | translate }}
         </button>
       </div>
     </form>


### PR DESCRIPTION
* Adapts record detail buttons according to UX chart.
* Adapts editor buttons according to UX chart.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Go to the document detail page. Edit/delete buttons are now according to UX.
- Go to a resource editor (patron_types, vendors, ...). Save/Cancel buttons are now according to UX.

![image](https://user-images.githubusercontent.com/10031585/81390462-cb596780-911b-11ea-8705-39f2848c1dcd.png)

![image](https://user-images.githubusercontent.com/10031585/81390435-bed50f00-911b-11ea-8dd0-91a64246ce7d.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
