### PR TITLE
ui: improve display of editor, brief and detail views

### DIFF
--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.html
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.html
@@ -14,27 +14,29 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div class="alert alert-danger" *ngIf="error">{{ error | translate }}</div>
-<div class="float-right ml-4 mt-2 mb-4" *ngIf="record && adminMode.can">
-    <a href class="btn btn-sm btn-primary" routerLink="../../edit/{{ record.metadata.pid }}"
-        *ngIf="updateStatus && updateStatus.can">
-        <i class="fa fa-pencil"></i>
-        {{ 'Edit' | translate }}
-    </a>
-    <ng-container *ngIf="deleteStatus">
-        <button class="btn btn-sm btn-outline-danger ml-1" [title]="'Delete'|translate"
-            (click)="deleteRecord(record.metadata.pid)" *ngIf="deleteStatus.can; else deleteMessageLink">
-            <i class="fa fa-trash"></i>
-            {{ 'Delete' | translate }}
-        </button>
-        <ng-template #deleteMessageLink>
-            <button class="btn btn-sm btn-outline-danger ml-1 disabled" [title]="'Delete'|translate"
-                (click)="showDeleteMessage(deleteStatus.message)" *ngIf="deleteStatus.message">
-                <i class="fa fa-trash mr-1"></i>{{ 'Delete' | translate }}
-            </button>
-        </ng-template>
-    </ng-container>
+<div class="main-content">
+  <div class="alert alert-danger" *ngIf="error">{{ error | translate }}</div>
+  <div class="float-right ml-4 mt-2 mb-4" *ngIf="record && adminMode.can">
+      <a href class="btn btn-sm btn-primary" [routerLink]="['../../edit', record.metadata.pid]"
+          *ngIf="updateStatus && updateStatus.can">
+          <i class="fa fa-pencil"></i>
+          {{ 'Edit' | translate }}
+      </a>
+      <ng-container *ngIf="deleteStatus">
+          <button class="btn btn-sm btn-outline-danger ml-1" [title]="'Delete'|translate"
+              (click)="deleteRecord(record.metadata.pid)" *ngIf="deleteStatus.can; else deleteMessageLink">
+              <i class="fa fa-trash"></i>
+              {{ 'Delete' | translate }}
+          </button>
+          <ng-template #deleteMessageLink>
+              <button class="btn btn-sm btn-outline-danger ml-1 disabled" [title]="'Delete'|translate"
+                  (click)="showDeleteMessage(deleteStatus.message)" *ngIf="deleteStatus.message">
+                  <i class="fa fa-trash mr-1"></i>{{ 'Delete' | translate }}
+              </button>
+          </ng-template>
+      </ng-container>
+    </div>
+    <ng-template ngCoreRecordDetail></ng-template>
+    <hr class="my-4">
+    <button class="btn btn-link" (click)="goBack()">&laquo; {{ 'Back' | translate }}</button>
 </div>
-<ng-template ngCoreRecordDetail></ng-template>
-<hr class="my-4">
-<button class="btn btn-link" (click)="goBack()">&laquo; {{ 'Back' | translate }}</button>

--- a/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.html
@@ -15,7 +15,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <!-- array title only if the array is empty -->
-<label *ngIf="to.label && to.hideLabel !== true && formControl && formControl.length === 0" [attr.for]="id">
+<label *ngIf="to.label && to.hideLabel !== true && formControl && formControl.length === 0" [attr.for]="id" [tooltip]="to.description">
   <!-- add button only if the max is not reached -->
   <a *ngIf="canAdd()" (click)="add(0)" class="btn btn-link btn-sm">
     <i class="fa fa-plus"></i>
@@ -83,7 +83,7 @@
 
 <!-- section title -->
 <ng-template #title let-f="f" let-i="i">
-  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id">
+  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id" [tooltip]="f.templateOptions.description">
     <a *ngIf="canAdd()" (click)="add(i + 1)" class="btn btn-link btn-sm">
       <i class="fa fa-plus"></i>
     </a>

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -84,6 +84,9 @@ export class EditorComponent implements OnInit, OnDestroy {
   // Config for resource
   private _resourceConfig: any;
 
+  // Types to apply horizontal wrapper on
+  private _horizontalWrapperTypes = ['enum', 'string', 'remoteautocomplete', 'integer'];
+
   /**
    * Constructor.
    * @param _formlyJsonschema Formly JSON schema.
@@ -284,6 +287,13 @@ export class EditorComponent implements OnInit, OnDestroy {
             ];
           }
 
+          // Add an horizontal wrapper
+          if (this._horizontalWrapperTypes.some(elem => elem === field.type)) {
+            field.wrappers = [
+              ...(field.wrappers ? field.wrappers : []),
+              'form-field-horizontal'
+            ];
+          }
           return field;
         }
       })

--- a/projects/rero/ng-core/src/lib/record/editor/horizontal-wrapper/horizontal-wrapper.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/horizontal-wrapper/horizontal-wrapper.component.ts
@@ -15,29 +15,27 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Component } from '@angular/core';
-import { FieldType } from '@ngx-formly/core';
+import { FieldWrapper } from '@ngx-formly/core';
 
-/**
- * Component for displaying a switcher in editor.
- */
 @Component({
-  selector: 'ng-core-editor-formly-field-switch',
+  selector: 'ng-core-horizontal-wrapper',
   template: `
-    <div class="custom-control custom-switch">
-      <input class="custom-control-input" type="checkbox"
-        [class.is-invalid]="showError"
-        [indeterminate]="to.indeterminate && formControl.value === null"
-        [formControl]="formControl"
-        [formlyAttributes]="field">
-      <label class="custom-control-label" [for]="id" [tooltip]="to.description">{{ to.label }}</label>
+    <div class="form-group">
+      <div class="row">
+        <label [attr.for]="id" class="col-sm-2 col-form-label" *ngIf="to.label" [tooltip]="to.description">
+          {{ to.label }}
+          <ng-container *ngIf="to.required && to.hideRequiredMarker !== true">*</ng-container>
+        </label>
+        <div class="col-sm-10">
+          <ng-template #fieldComponent></ng-template>
+        </div>
+      </div>
+      <div *ngIf="showError" class="row invalid-feedback d-block">
+        <formly-validation-message [field]="field"></formly-validation-message>
+      </div>
     </div>
   `,
 })
-export class SwitchComponent extends FieldType {
-  defaultOptions = {
-    templateOptions: {
-      indeterminate: true,
-      hideLabel: true,
-    },
-  };
+export class HorizontalWrapperComponent extends FieldWrapper {
+
 }

--- a/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
@@ -75,7 +75,7 @@
 
 <!-- section title -->
 <ng-template #title let-f="f">
-  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id">
+  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id" [tooltip]="f.templateOptions.description">
     {{ f.templateOptions.label }}
     <span *ngIf="f.templateOptions.required && f.templateOptions.hideRequiredMarker !== true">*</span>
   </label>

--- a/projects/rero/ng-core/src/lib/record/editor/toggle-wrapper/toggle-wrappers.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/toggle-wrapper/toggle-wrappers.component.ts
@@ -25,7 +25,7 @@ import { isEmpty, removeEmptyValues } from '../utils';
       <div class='form-group'>
         <div class="custom-control custom-switch">
           <input class="custom-control-input" type="checkbox" id="toggle-switch" (change)="toggle($event)" [checked]="tsOptions.enabled">
-          <label class="custom-control-label" for="toggle-switch">{{ tsOptions.label }}</label>
+          <label class="custom-control-label" for="toggle-switch" [tooltip]="tsOptions.description">{{ tsOptions.label }}</label>
         </div>
         <small class="form-text text-muted" *ngIf="tsOptions.description">{{ tsOptions.description }}</small>
       </div>

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -19,8 +19,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
 import { FormlyModule } from '@ngx-formly/core';
-import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
+import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { PaginationModule } from 'ngx-bootstrap/pagination';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
@@ -35,6 +35,7 @@ import { ArrayTypeComponent } from './editor/array-type/array-type.component';
 import { DropdownLabelEditorComponent } from './editor/dropdown-label-editor/dropdown-label-editor.component';
 import { EditorComponent } from './editor/editor.component';
 import { hooksFormlyExtension } from './editor/extensions';
+import { HorizontalWrapperComponent } from './editor/horizontal-wrapper/horizontal-wrapper.component';
 import { MultiSchemaTypeComponent } from './editor/multischema/multischema.component';
 import { ObjectTypeComponent } from './editor/object-type/object-type.component';
 import { SwitchComponent } from './editor/switch/switch.component';
@@ -72,7 +73,8 @@ import { RecordSearchResultDirective } from './search/result/record-search-resul
     MultiSchemaTypeComponent,
     DatepickerTypeComponent,
     ToggleWrapperComponent,
-    BucketsComponent
+    BucketsComponent,
+    HorizontalWrapperComponent
   ],
   imports: [
     CoreModule,
@@ -140,7 +142,8 @@ import { RecordSearchResultDirective } from './search/result/record-search-resul
         { name: 'datepicker', component: DatepickerTypeComponent }
       ],
       wrappers: [
-        { name: 'toggle-switch', component: ToggleWrapperComponent }
+        { name: 'toggle-switch', component: ToggleWrapperComponent },
+        { name: 'form-field-horizontal', component: HorizontalWrapperComponent }
       ]
     }),
     FormlyBootstrapModule

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -31,7 +31,7 @@
       </a>
     </li>
   </ul>
-  <div *ngIf="!isLoading; else loading">
+  <div *ngIf="!isLoading; else loading" class="main-content">
     <div class="row align-items-center my-3">
       <div class="col-sm-3 mb-3 mb-sm-0" *ngIf="showSearchInput">
         <ng-core-search-input


### PR DESCRIPTION
* Adds horizontal wrapper to move editor labels next to the input.
* Compacts brief and detail views to not use the whole width of the window.
* Displays description in tooltips in editor.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

Implements task 1473 of US1296

https://tree.taiga.io/project/rero21-reroils/us/1296?milestone=263424
https://tree.taiga.io/project/rero21-reroils/task/1473?kanban-status=1224894

## How to test?

Use https://github.com/rero/rero-ils/pull/983 and https://github.com/rero/rero-ils-ui/pull/267

Use `npm pack` or `npm link` to install this PR on rero-ils-ui, which needs to be installed in rero-ils after that.
Go to document editor and check that the labels are next to the inputs (same line, not above).

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
