### PR TITLE
translations: add http translations support

### DIFF
--- a/projects/ng-core-tester/src/app/app-config.service.ts
+++ b/projects/ng-core-tester/src/app/app-config.service.ts
@@ -36,6 +36,6 @@ export class AppConfigService extends CoreConfigService {
     this.schemaFormEndpoint = '/api/schemaform';
     this.$refPrefix = environment.$refPrefix;
     this.languages = environment.languages;
-    this.customTranslations = environment.customTranslations;
+    this.translationsURLs = environment.translationsURLs;
   }
 }

--- a/projects/ng-core-tester/src/assets/i18n/fr.json
+++ b/projects/ng-core-tester/src/assets/i18n/fr.json
@@ -1,0 +1,3 @@
+{
+  "search": "Rechercher une ressource"
+}

--- a/projects/ng-core-tester/src/environments/environment.prod.ts
+++ b/projects/ng-core-tester/src/environments/environment.prod.ts
@@ -20,9 +20,7 @@ export const environment = {
   apiBaseUrl: 'https://localhost:5000',
   $refPrefix: 'https://sonar.ch',
   languages: ['fr', 'de', 'it', 'en'],
-  customTranslations: {
-    fr: {
-      search: 'Rechercher une ressource'
-    }
-  }
+  translationsURLs: [
+    '/assets/i18n/${lang}.json'
+  ]
 };

--- a/projects/ng-core-tester/src/environments/environment.ts
+++ b/projects/ng-core-tester/src/environments/environment.ts
@@ -25,11 +25,9 @@ export const environment = {
   apiBaseUrl: 'https://localhost:5000',
   $refPrefix: 'https://sonar.ch',
   languages: ['fr', 'de', 'it', 'en'],
-  customTranslations: {
-    fr: {
-      search: 'Rechercher une ressource'
-    }
-  }
+  translationsURLs: [
+    '/assets/i18n/${lang}.json'
+  ]
 };
 
 /*

--- a/projects/rero/ng-core/src/lib/core-config.service.ts
+++ b/projects/rero/ng-core/src/lib/core-config.service.ts
@@ -29,12 +29,7 @@ export interface Config {
   languages?: string[];
   defaultLanguage?: string;
   secretPassphrase: string;
-  customTranslations?: {
-      fr?: {},
-      de?: {},
-      en?: {},
-      it?: {}
-  };
+  translationsURLs?: Array<any>;
 }
 
 /**
@@ -53,5 +48,5 @@ export class CoreConfigService implements Config {
   languages = ['en'];
   defaultLanguage = 'en';
   secretPassphrase = 'ShERWIN53SnAggIng48rELAtiVes';
-  customTranslations = null;
+  translationsURLs = [];
 }

--- a/projects/rero/ng-core/src/lib/translate/translate-loader.ts
+++ b/projects/rero/ng-core/src/lib/translate/translate-loader.ts
@@ -14,9 +14,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { HttpClient } from '@angular/common/http';
 import { Inject } from '@angular/core';
 import { TranslateLoader as BaseTranslateLoader } from '@ngx-translate/core';
-import { Observable, of } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { CoreConfigService } from '../core-config.service.js';
 import de from './i18n/de.json';
 import en from './i18n/en.json';
@@ -27,43 +29,62 @@ import it from './i18n/it.json';
  * Loader for translations used in ngx-translate library.
  */
 export class TranslateLoader implements BaseTranslateLoader {
-  /**
-   * Store translations in available languages.
-   */
-  translations: object = { fr, de, en, it };
 
+  // translations
+  private _translations = {};
+
+  // locale translations
+  // with angular<9 assets are not available for libraries
+  // See: https://angular.io/guide/creating-libraries#managing-assets-in-a-library
+  private _coreTranslations = { de, en, fr, it };
   /**
    * Constructor.
    *
    * @param _coreConfigService Configuration service.
    */
-  constructor(@Inject(CoreConfigService) private _coreConfigService: CoreConfigService) {
-    this.loadCustomTranslations();
-  }
-
-  /**
-   * Load custom translations
-   */
-  private loadCustomTranslations() {
-    if (!this._coreConfigService.customTranslations) {
-      return;
-    }
-
-    for (const lang of this._coreConfigService.languages) {
-      if (this.translations[lang] && this._coreConfigService.customTranslations[lang]) {
-        this.translations[lang] = { ...this.translations[lang], ...this._coreConfigService.customTranslations[lang] };
-      }
-    }
-  }
+  constructor(
+    @Inject(CoreConfigService) private _coreConfigService: CoreConfigService,
+    @Inject(HttpClient) private _http: HttpClient
+  ) { }
 
   /**
    * Return observable used by ngx-translate to get translations.
    * @param lang - string, language to rerieve translations from.
    */
   getTranslation(lang: string): Observable<any> {
-    if (!this.translations[lang]) {
-      throw new Error(`Translations not found for lang "${lang}"`);
+    // Already in cache
+    if (this._translations[lang] != null) {
+      return of(this._translations[lang]);
     }
-    return of(this.translations[lang]);
+    const urls = this._coreConfigService.translationsURLs;
+    // create the list of http requests
+    const observers = urls.map(
+      url => {
+        const langURL = url.replace('${lang}', lang);
+        return this._http.get(langURL).pipe(
+          catchError((err) => {
+            console.log(`ERROR: Cannot load translation: ${langURL}`);
+            return of([]);
+          })
+        );
+      }
+    );
+    // Get local and backend translations
+    return forkJoin(observers).pipe(
+      map((translations) => {
+        // copy local translations
+        if (this._coreTranslations[lang] != null) {
+          this._translations[lang] = { ...this._coreTranslations[lang] };
+        }
+        // get remote translations
+        translations.map(trans =>
+          this._translations[lang] = {
+            ...this._translations[lang],
+            ...trans
+          }
+        );
+        return this._translations[lang];
+      })
+    );
   }
 }


### PR DESCRIPTION
* Removes `customTranslations` property.
* Adds `translationsURLs` to provide a list of remote translations.
* Changes the demo applications accordingly.
* Simplifies the tests.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>


## Used by:
- rero/rero-ils: https://github.com/rero/rero-ils/pull/997
- rero/rero-ils-ui: https://github.com/rero/rero-ils-ui/pull/271

## Why are you opening this PR?

- To allows a server to provide custom translations.

## How to test?

- Look at the application demo and see the translations configurations and if it is works.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
