### PR TITLE
editor: display fields inline 

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.html
@@ -17,10 +17,10 @@
 <!-- array title only if the array is empty -->
 <label *ngIf="to.label && to.hideLabel !== true && formControl && formControl.length === 0" [attr.for]="id" [tooltip]="to.description">
   <!-- add button only if the max is not reached -->
+  <span [tooltip]="to.description">{{ to.label }}</span>
   <a *ngIf="canAdd()" (click)="add(0)" class="btn btn-link btn-sm">
     <i class="fa fa-plus"></i>
   </a>
-  <span [tooltip]="to.description">{{ to.label }}</span>
   <span *ngIf="to.required && to.hideRequiredMarker !== true">*</span>
 </label>
 
@@ -30,13 +30,11 @@
 </div>
 
 <!-- for each item -->
-
 <ng-container *ngFor="let f of field.fieldGroup; let i = index">
   <!-- put title with menu section for item object -->
-  <div *ngIf="isChildrenObject">
+  <div *ngIf="isChildrenObject" class="header ml-4">
     <ng-container *ngTemplateOutlet="hasMenu(f) ? menu : title; context: { f: f, i: i }">
     </ng-container>
-
     <!--  object validation error message -->
     <div class="alert alert-danger" role="alert" *ngIf="f.options.showError && f.formControl.errors">
       <formly-validation-message [field]="f"></formly-validation-message>
@@ -44,65 +42,77 @@
   </div>
 
   <!-- all kind of item -->
-  <div class="d-flex mb-2" [ngClass]="{ 'pl-2 border-left': isChildrenObject }">
-    <!-- add button -->
-    <ng-container *ngTemplateOutlet="addButton; context: { i: i }"></ng-container>
+  <div class="row mb-2 content ml-4" [ngClass]="{ 'pl-2 border-left': isChildrenObject }"
+  (mouseenter)="show = true"
+  (mouseleave)="show = false">
     <!-- item itself -->
-    <div class="flex-grow-1">
+    <div class="col-auto"
+    [ngClass]="{'col-lg-11': f.type === 'textarea' || f.type === 'string' || f.type === 'object' || f.type === 'array'}">
       <!-- add label for array of arrays -->
       <span *ngIf="isChildrenArray">{{f.templateOptions.label}}</span>
       <formly-field [field]="f"></formly-field>
     </div>
-    <!-- remove button -->
-    <ng-container *ngTemplateOutlet="removeButton; context: { i: i }"></ng-container>
+    <div class="col" *ngIf="show && !isChildrenObject">
+      <button *ngIf="canAdd()" (click)="add(i + 1)" class="btn btn-outline-secondary btn-sm mr-1">
+        <i class="fa fa-clone"></i>
+      </button>
+      <button (click)="remove(i)" *ngIf="canRemove()" class="btn btn-outline-secondary btn-sm">
+        <i class="fa fa-trash"></i>
+      </button>
+    </div>
   </div>
 </ng-container>
 
 <!-- TEMPLATES -->
 <!-- dropdown menu -->
 <ng-template #menu let-f="f" let-i="i">
-  <ng-core-editor-dropdown-label-editor [field]="f" [canAdd]="canAdd()" (addClicked)="add(i + 1)">
-    <ng-container *ngIf="f.type === 'object'">
-      <ng-container *ngFor="
-          let fChildren of hiddenFieldGroup(f.fieldGroup);
-          let first = first;
-          let last = last
-        ">
-        <h6 *ngIf="first" class="dropdown-header" translate>Add fields</h6>
-        <button class="dropdown-item" (click)="fChildren.hide = false" type="button">
-          {{ fChildren.templateOptions.label }}
-        </button>
-        <div *ngIf="last && f.templateOptions.helpURL" class="dropdown-divider"></div>
+  <ng-core-editor-dropdown-label-editor [field]="f">
+    <ng-container dropdown-list>
+      <ng-container *ngIf="f.type === 'object'">
+        <ng-container *ngFor="
+            let fChildren of hiddenFieldGroup(f.fieldGroup);
+            let first = first;
+            let last = last
+          ">
+          <h6 *ngIf="first" class="dropdown-header" translate>Add fields</h6>
+          <button class="dropdown-item" (click)="fChildren.hide = false" type="button">
+            {{ fChildren.templateOptions.label }}
+          </button>
+          <div *ngIf="last && f.templateOptions.helpURL" class="dropdown-divider"></div>
+        </ng-container>
       </ng-container>
+      <a *ngIf="f.templateOptions.helpURL" class="dropdown-item" [href]="f.templateOptions.helpURL" translate>
+        Help
+      </a>
     </ng-container>
-    <a *ngIf="f.templateOptions.helpURL" class="dropdown-item" [href]="f.templateOptions.helpURL" translate>
-      Help
-    </a>
+    <ng-container buttons>
+      <button *ngIf="canAdd()" (click)="add(i + 1)" class="btn btn-link text-secondary btn-sm ml-2">
+        <i class="fa fa-clone"></i>
+      </button>
+      <button (click)="remove(i)" *ngIf="canRemove()" class="btn btn-link text-secondary btn-sm">
+        <i class="fa fa-trash"></i>
+      </button>
+    </ng-container>
   </ng-core-editor-dropdown-label-editor>
 </ng-template>
 
 <!-- section title -->
 <ng-template #title let-f="f" let-i="i">
-  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id" [tooltip]="f.templateOptions.description">
-    <a *ngIf="canAdd()" (click)="add(i + 1)" class="btn btn-link btn-sm">
-      <i class="fa fa-plus"></i>
-    </a>
+  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true"
+  [attr.for]="f.id"
+  [tooltip]="f.templateOptions.description"
+  (mouseenter)="show = true"
+  (mouseleave)="show = false">
     {{ f.templateOptions.label }}
     <span *ngIf="f.templateOptions.required && f.templateOptions.hideRequiredMarker !== true">*</span>
+    <!-- add and remove buttons -->
+    <ng-container *ngIf="show">
+      <a *ngIf="canAdd()" (click)="add(i + 1)" class="btn btn-link text-secondary btn-sm">
+        <i class="fa fa-clone"></i>
+      </a>
+      <a (click)="remove(i)" *ngIf="canRemove()" class="btn btn-link text-secondary btn-sm">
+        <i class="fa fa-trash"></i>
+      </a>
+    </ng-container>
   </label>
-</ng-template>
-
-<!-- add button -->
-<ng-template #addButton let-i="i">
-  <a *ngIf="!isChildrenObject && canAdd()" (click)="add(i + 1)" class="btn btn-link btn-sm">
-    <i class="fa fa-plus"></i>
-  </a>
-</ng-template>
-
-<!-- tash button -->
-<ng-template #removeButton let-i="i">
-  <button (click)="remove(i)" *ngIf="canRemove()" class="btn btn-outline-secondary ml-1 btn-sm"
-    [ngClass]="{ 'mb-2': isChildrenObject }">
-    <i class="fa fa-trash"></i>
-  </button>
 </ng-template>

--- a/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.ts
@@ -31,6 +31,9 @@ export class ArrayTypeComponent extends FieldArrayType implements OnInit {
   /** True if the children are of type array */
   isChildrenArray = false;
 
+  /** Show or hide button */
+  show = false;
+
   /**
    * Component initialization
    */
@@ -63,7 +66,7 @@ export class ArrayTypeComponent extends FieldArrayType implements OnInit {
   }
 
   /**
-   * Is a new element can be added?
+   * Can a new element be added?
    * @returns boolean, true if a new element can be inserted in the array
    */
   canAdd(): boolean {
@@ -87,6 +90,16 @@ export class ArrayTypeComponent extends FieldArrayType implements OnInit {
   }
 
   /**
+   * Remove an element from the array and hide buttons
+   * @param i - number, the position to remove the element
+   */
+  remove(i: number) {
+
+    super.remove(i);
+    this.show = false;
+  }
+
+  /**
    * Add a new element in the array
    * @param i - number, the position to add the element
    */
@@ -94,6 +107,7 @@ export class ArrayTypeComponent extends FieldArrayType implements OnInit {
     // TODO: focus in the first input child
     super.add(i, initialModel);
     this.setFocusInChildren(this.field.fieldGroup[i]);
+    this.show = false;
   }
 
   /**

--- a/projects/rero/ng-core/src/lib/record/editor/dropdown-label-editor/dropdown-label-editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/dropdown-label-editor/dropdown-label-editor.component.html
@@ -14,39 +14,34 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div *ngIf="field.templateOptions.label" class="d-block">
-  <!-- add button -->
-  <a
-    *ngIf="canAdd"
-    (click)="addClick($event)"
-    class="btn btn-link btn-sm mr-1"
-  >
-    <i class="fa fa-plus"></i>
-  </a>
+<div *ngIf="field.templateOptions.label" class="d-block"
+  (mouseenter)="show = true"
+  (mouseleave)="show = false">
+  <span [tooltip]="field.templateOptions.description">
+    {{ field.templateOptions.label }}
+    <span *ngIf="field.templateOptions.required">*</span>
+  </span>
   <!-- dropdown button with legend -->
-  <div class="btn-group" dropdown>
-  <button
-    [id]="field.id"
-    dropdownToggle
-    type="button"
-    class="btn btn-link dropdown-toggle text-decoration-none text-reset p-0 dropdown-toggle"
-    aria-controls="dropdown-basic"
-  >
-    <span [tooltip]="field.templateOptions.description">
-      {{ field.templateOptions.label }}
-      <span *ngIf="field.templateOptions.required">*</span>
-    </span>
-    <span class="ml-2 caret"></span>
-  </button>
-  <!-- dropdown list -->
-  <div
-    id="dropdown-basic"
-    *dropdownMenu
-    class="dropdown-menu"
-    role="menu"
-    aria-labelledby="button-basic"
-  >
-    <ng-content></ng-content>
-  </div>
+  <div *ngIf="show" class="btn-group" dropdown>
+    <!-- add subfield button -->
+    <button
+      [id]="field.id"
+      dropdownToggle
+      type="button"
+      class="btn btn-link dropdown-toggle text-decoration-none text-reset p-0 dropdown-toggle"
+      aria-controls="dropdown-basic">
+      <i class="ml-2 caret"></i>
+    </button>
+    <!-- dropdown list -->
+    <div
+      id="dropdown-basic"
+      *dropdownMenu
+      class="dropdown-menu"
+      role="menu"
+      aria-labelledby="button-basic">
+      <ng-content select="[dropdown-list]"></ng-content>
+    </div>
+    <!-- clone button -->
+    <ng-content select="[buttons]"></ng-content>
   </div>
 </div>

--- a/projects/rero/ng-core/src/lib/record/editor/dropdown-label-editor/dropdown-label-editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/dropdown-label-editor/dropdown-label-editor.component.ts
@@ -25,6 +25,9 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
   templateUrl: './dropdown-label-editor.component.html'
 })
 export class DropdownLabelEditorComponent {
+  /** Show or hide buttons */
+  show = false;
+
   // current form field configuration
   @Input()
   field: FormlyFieldConfig;

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -72,7 +72,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
   private _resourceConfig: any;
 
   // Types to apply horizontal wrapper on
-  private _horizontalWrapperTypes = ['enum', 'string', 'remoteautocomplete', 'integer'];
+  private _horizontalWrapperTypes = ['enum', 'string', 'remoteautocomplete', 'integer', 'textarea'];
 
   /**
    * Constructor.

--- a/projects/rero/ng-core/src/lib/record/editor/horizontal-wrapper/horizontal-wrapper.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/horizontal-wrapper/horizontal-wrapper.component.ts
@@ -22,16 +22,16 @@ import { FieldWrapper } from '@ngx-formly/core';
   template: `
     <div class="form-group">
       <div class="row">
-        <label [attr.for]="id" class="col-sm-2 col-form-label" *ngIf="to.label" [tooltip]="to.description">
+        <label [attr.for]="id" class="col-sm-auto col-form-label" *ngIf="to.label" [tooltip]="to.description">
           {{ to.label }}
           <ng-container *ngIf="to.required && to.hideRequiredMarker !== true">*</ng-container>
         </label>
-        <div class="col-sm-10">
+        <div class="col">
           <ng-template #fieldComponent></ng-template>
+          <div *ngIf="showError" class="invalid-feedback d-block">
+            <formly-validation-message [field]="field"></formly-validation-message>
+          </div>
         </div>
-      </div>
-      <div *ngIf="showError" class="row invalid-feedback d-block">
-        <formly-validation-message [field]="field"></formly-validation-message>
       </div>
     </div>
   `,

--- a/projects/rero/ng-core/src/lib/record/editor/multischema/multischema.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/multischema/multischema.component.ts
@@ -21,8 +21,7 @@ import { FieldType } from '@ngx-formly/core';
   selector: 'ng-core-editor-formly-multi-schema-type',
   template: `
     <div>
-      <legend *ngIf="to.label">{{ to.label }}</legend>
-      <p *ngIf="to.description">{{ to.description }}</p>
+      <legend *ngIf="to.label" [tooltip]="to.description">{{ to.label }} </legend>
       <div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
         <formly-validation-message [field]="field"></formly-validation-message>
       </div>

--- a/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
@@ -27,27 +27,28 @@
 </div>
 
 <!-- each object properties -->
-<ng-container *ngFor="let f of field.fieldGroup">
-  <div class="">
-    <!-- if the field is repeatable the title is rendered by the corresponding array -->
-    <ng-container *ngIf="
-      !f.hide &&
-      ((!isParrentArray() && f.type === 'object') || f.type === 'array')
-    ">
-      <!-- section header -->
-      <ng-container *ngTemplateOutlet="hasMenu(f) ? menu : title; context: { f: f }">
+<div class="{{ getCssClass() }}">
+  <ng-container *ngFor="let f of field.fieldGroup">
+    <div class="{{ getCssClass(f) }}" *ngIf="!f.hide">
+      <!-- if the field is repeatable the title is rendered by the corresponding array -->
+      <ng-container *ngIf="((!isParrentArray() && f.type === 'object') || f.type === 'array')">
+        <!-- section header -->
+        <ng-container *ngTemplateOutlet="hasMenu(f) ? menu : title; context: { f: f }">
+        </ng-container>
       </ng-container>
-    </ng-container>
-
-    <!-- field + trash button-->
-    <div class="d-flex pl-2" [ngClass]="{ 'border-left': f.type === 'object' }">
-      <div class="flex-grow-1">
-        <formly-field [field]="f"></formly-field>
+      <!-- field -->
+      <div class="d-flex pl-2 content ml-2" [ngClass]="{ 'border-left': f.type === 'object', 'ml-4' : isParrentArray() }"
+      (mouseenter)="isShown = true" (mouseleave)="isShown = false">
+        <div class="flex-grow-1">
+          <formly-field [field]="f"></formly-field>
+        </div>
+        <ng-container *ngIf="f.type !== 'array' && isShown">
+          <ng-container *ngTemplateOutlet="hideButtonOutline; context: { f: f }"></ng-container>
+        </ng-container>
       </div>
-      <ng-container *ngTemplateOutlet="hideButton; context: { f: f }"></ng-container>
     </div>
-  </div>
-</ng-container>
+  </ng-container>
+</div>
 
 <!-- TEMPLATES -->
 <!-- dropdown menu -->
@@ -59,7 +60,7 @@
           let first = first;
           let last = last
         ">
-        <h6 *ngIf="first" class="dropdown-header">Add fields</h6>
+        <h6 *ngIf="first" class="dropdown-header" translate>Add fields</h6>
         <button class="dropdown-item" (click)="show(fChildren)" type="button">
           {{ fChildren.templateOptions.label }}
         </button>
@@ -75,15 +76,25 @@
 
 <!-- section title -->
 <ng-template #title let-f="f">
-  <label *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id" [tooltip]="f.templateOptions.description">
-    {{ f.templateOptions.label }}
-    <span *ngIf="f.templateOptions.required && f.templateOptions.hideRequiredMarker !== true">*</span>
-  </label>
+  <div class="header" (mouseenter)="isShown = true" (mouseleave)="isShown = false">
+    <label class="ml-3" *ngIf="f.templateOptions.label && f.templateOptions.hideLabel !== true" [attr.for]="f.id" [tooltip]="f.templateOptions.description">
+      {{ f.templateOptions.label }}
+      <span *ngIf="f.templateOptions.required && f.templateOptions.hideRequiredMarker !== true">*</span>
+    </label>
+    <ng-container *ngIf="isShown">
+      <ng-container *ngTemplateOutlet="hideButtonLink; context: { f: f }"></ng-container>
+    </ng-container>
+  </div>
 </ng-template>
 
 <!-- trash button -->
-<ng-template #hideButton let-f="f">
-  <button type="button" (click)="hide(f)" *ngIf="canHide(f)" class="btn btn-outline-secondary ml-1 btn-sm">
+<ng-template #hideButtonLink let-f="f">
+  <button type="button" (click)="hide(f)" *ngIf="canHide(f)" class="btn btn-link text-secondary mb-1 btn-sm">
+    <i class="fa fa-trash"></i>
+  </button>
+</ng-template>
+<ng-template #hideButtonOutline let-f="f">
+  <button type="button" (click)="hide(f)" *ngIf="canHide(f)" class="btn btn-outline-secondary mb-1 btn-sm">
     <i class="fa fa-trash"></i>
   </button>
 </ng-template>

--- a/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.ts
@@ -31,6 +31,9 @@ export class ObjectTypeComponent extends FieldType {
     defaultValue: {}
   };
 
+  /** Show or hide button */
+  isShown = false;
+
   /**
    * Constructor
    * @param editorService - EditorService, that keep the list of hidden fields
@@ -125,5 +128,18 @@ export class ObjectTypeComponent extends FieldType {
       !field.hide &&
       field.hideExpression == null
     );
+  }
+
+  /**
+   * Get css class declared in template options
+   *
+   * @param field field to apply css class to
+   * @return css class to apply
+   */
+  getCssClass(field: FormlyFieldConfig = null): string {
+    if (field !== null) {
+      return field.templateOptions.cssClass;
+    }
+    return this.to.cssClass;
   }
 }


### PR DESCRIPTION
* Adapts editor to use css class from jsonschema.
* Displays description in editor for multischema fields.
* Displays a background on mouse hover on title to highlight a block.
* Hide "add","hide"  and "show" buttons and shows them on mouse hover.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

It's part of https://tree.taiga.io/project/rero21-reroils/us/1296?milestone=263424 (UX of editor)

## How to test?

Needs https://github.com/rero/rero-ils/pull/1006 and https://github.com/rero/rero-ils-ui/pull/267
1. Go to document editor
1. Check that fields of nth level are displayed inline. Example:

![editor](https://user-images.githubusercontent.com/28982829/82885023-d9ddb680-9f44-11ea-9202-39310c5d1328.png)

3. Check that other display is not broken.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
