### PR TITLE
validator : add custom unique validator for complex object.

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -495,6 +495,31 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
           };
           delete formOptions.validation.validators.valueAlreadyExists;
         }
+        // asyncValidators: valueKeysInObject
+        //  This validator is similar to uniqueValidator but only check on some specific fields of array items.
+        if (formOptions.validation.validators.uniqueValueKeysInObject) {
+          field.validators = {
+            uniqueValueKeysInObject: {
+              expression: (control: FormControl) => {
+                // if value isn't an array or array contains less than 2 elements, no need to check
+                if (!(control.value instanceof Array) || control.value.length < 2) {
+                  return true;
+                }
+                const keysToKeep = formOptions.validation.validators.uniqueValueKeysInObject.keys;
+                const uniqueItems = Array.from(
+                   new Set(control.value.map((v: any) => {
+                     const keys = keysToKeep.reduce((acc, elt) => {
+                       acc[elt] = v[elt];
+                       return acc;
+                     }, {});
+                     return JSON.stringify(keys);
+                   })),
+                );
+                return uniqueItems.length === control.value.length;
+              }
+            }
+          };
+        }
         // validators: add validator with expressions
         const validatorsKey = Object.keys(formOptions.validation.validators);
         validatorsKey.map(validatorKey => {

--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -122,6 +122,10 @@ export function registerTranslateExtension(translate: TranslateService) {
         message: () => translate.stream(_('should NOT have duplicate items'))
       },
       {
+        name: 'uniqueValueKeysInObject',
+        message: () => translate.stream(_('should NOT have duplicate items'))
+      },
+      {
         name: 'alreadyTaken',
         message: () => translate.stream(_('the value is already taken'))
       },


### PR DESCRIPTION
This PR adds a custom validator to check if complex object are unique
into an array of objects. Comparing to UniqueValidator from ngx-formly,
this new validator allows to specify which objects keys should be used
to compare if values are unique into an array.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
