### PR TITLE
detailed view: redirect after record deletion

### DIFF
--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.html
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.html
@@ -24,7 +24,7 @@
       </a>
       <ng-container *ngIf="deleteStatus">
           <button class="btn btn-sm btn-outline-danger ml-1" [title]="'Delete'|translate"
-              (click)="deleteRecord(record.metadata.pid)" *ngIf="deleteStatus.can; else deleteMessageLink">
+              (click)="deleteRecord(record)" *ngIf="deleteStatus.can; else deleteMessageLink">
               <i class="fa fa-trash"></i>
               {{ 'Delete' | translate }}
           </button>


### PR DESCRIPTION
* Allows to redirect to the parent with an object or a string after record deletion.
* Closes rero/rero-ils#1024.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- To fix the redirect url after delete a record on detail view

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
