### PR TITLE
menu: add prefix and suffix options on submenu item

### DIFF
--- a/projects/rero/ng-core/src/lib/widget/menu/menu.component.html
+++ b/projects/rero/ng-core/src/lib/widget/menu/menu.component.html
@@ -41,20 +41,51 @@
         </a>
         <div *dropdownMenu class="dropdown-menu" role="menu" [ngClass]="menu.hasOwnProperty('dropdownMenuCssClass') ? menu.dropdownMenuCssClass : ''">
           <ng-container *ngFor="let subItem of item.entries | callbackArrayFilter: isItemMenuVisible" [ngSwitch]="itemType(subItem)">
-            <a *ngSwitchCase="'routerLink'" [routerLink]="subItem.routerLink" [queryParams]="subItem.queryParams ? subItem.queryParams : {}"
-            [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'dropdown-item'"
-            ><i *ngIf="subItem.iconCssClass" [ngClass]="subItem.iconCssClass" aria-hidden="true"></i> {{ subItem.name|translate }}</a>
+            <a *ngSwitchCase="'routerLink'"
+               [routerLink]="subItem.routerLink" [queryParams]="subItem.queryParams ? subItem.queryParams : {}"
+               [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'dropdown-item'"
+            >
+              <span *ngIf="subItem.prefix" class="pr-2 text-dark small font-weight-bold">
+                {{ subItem.prefix|translate }}
+              </span>
+              <i *ngIf="subItem.iconCssClass" [ngClass]="subItem.iconCssClass" aria-hidden="true"></i>
+              {{ subItem.name|translate }}
+              <span *ngIf="subItem.suffix" class="pl-2 text-info small font-weight-bold">
+                {{ subItem.suffix|translate }}
+              </span>
+            </a>
 
-            <a *ngSwitchCase="'href'" [href]="subItem.href"
-            [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'dropdown-item'"
-            ><i *ngIf="subItem.iconCssClass" [ngClass]="subItem.iconCssClass" aria-hidden="true"></i> {{ subItem.name|translate }}</a>
+            <a *ngSwitchCase="'href'"
+               [href]="subItem.href"
+               [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'dropdown-item'"
+            >
+              <span *ngIf="subItem.prefix" class="pr-2 text-dark small font-weight-bold">
+                {{ subItem.prefix|translate }}
+              </span>
+              <i *ngIf="subItem.iconCssClass" [ngClass]="subItem.iconCssClass" aria-hidden="true"></i>
+              {{ subItem.name|translate }}
+              <span *ngIf="subItem.suffix" class="pl-2 text-info small font-weight-bold">
+                {{ subItem.suffix|translate }}
+              </span>
+            </a>
 
             <div *ngSwitchCase="'divider'" class="dropdown-divider"></div>
 
-            <a *ngSwitchDefault href="#"
-            [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'dropdown-item'"
-            (click)="doClickItem($event, subItem)"
-            ><i *ngIf="subItem.iconCssClass" [ngClass]="subItem.iconCssClass" aria-hidden="true"></i> {{subItem.name|translate }}</a>
+            <a *ngSwitchDefault
+               href="#"
+               [ngClass]="menu.hasOwnProperty('linkCssClass')? menu.linkCssClass : 'dropdown-item'"
+               class="clearfix"
+               (click)="doClickItem($event, subItem)"
+            >
+              <span *ngIf="subItem.prefix" class="pr-2 text-dark small font-weight-bold">
+                {{ subItem.prefix|translate }}
+              </span>
+              <i *ngIf="subItem.iconCssClass" [ngClass]="subItem.iconCssClass" aria-hidden="true"></i>
+              {{subItem.name|translate }}
+              <span *ngIf="subItem.suffix" class="pl-2 text-info small font-weight-bold">
+                {{ subItem.suffix|translate }}
+              </span>
+            </a>
           </ng-container>
         </div>
       </li>


### PR DESCRIPTION
This commit defines two new options for any sub menu item : prefix and
suffix. Prefix will be display as dark bold text ; suffix will be
display as dark info text.

![image](https://user-images.githubusercontent.com/10031585/85129152-eea32680-b232-11ea-9780-6a1b532aa700.png)


Co-authored_by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
