### PR TITLE
record: allow to use headers in getRecord pipe

### DIFF
--- a/projects/rero/ng-core/src/lib/pipe/get-record.pipe.ts
+++ b/projects/rero/ng-core/src/lib/pipe/get-record.pipe.ts
@@ -42,7 +42,7 @@ export class GetRecordPipe implements PipeTransform {
    * @param field Field to return.
    * @return Record or field record corresponding to PID.
    */
-  transform(pid: any, type: string, returnType = 'object', field?: string): any {
+  transform(pid: any, type: string, returnType = 'object', field?: string, headers?: object): any {
     // process $ref entrypoint
     if (pid.startsWith('http')) {
       pid = extractIdOnRef(pid);
@@ -52,7 +52,7 @@ export class GetRecordPipe implements PipeTransform {
       returnType = 'field';
     }
 
-    return this._recordService.getRecord(type, pid, 1).pipe(map(data => {
+    return this._recordService.getRecord(type, pid, 1, headers).pipe(map(data => {
       if (!data) {
         return null;
       }


### PR DESCRIPTION
* Adds a parameter to allow using headers in getRecord pipe.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

To allow the use of headers in getRecord pipe.

## How to test?

Needs https://github.com/rero/rero-ils/pull/1046 and https://github.com/rero/rero-ils-ui/pull/283.
Create or edit a document with partOf field.
Check that the title of the host document is displayed.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
