### PR TITLE
search: make the number of results configurable

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -32,6 +32,9 @@
     </li>
   </ul>
   <div *ngIf="!isLoading; else loading" class="main-content">
+    <h5 *ngIf="types.length == 1 && showLabel">
+      {{ types[0].label | translate }}
+    </h5>
     <div class="row align-items-center my-3">
       <div class="col-sm-3 mb-3 mb-sm-0" *ngIf="showSearchInput">
         <ng-core-search-input
@@ -43,8 +46,8 @@
         >
         </ng-core-search-input>
       </div>
-      <div class="col-6 col-sm-3">
-        <strong>{{ total }} {{ 'results' | translate }}</strong>
+      <div *ngIf="resultsText$ | async as resultsText" class="col-6 col-sm-3">
+        <strong>{{ resultsText }}</strong>
       </div>
       <div class="col ml-auto text-right">
         <a class="btn btn-primary" routerLink="new" *ngIf="adminMode.can && addStatus.can">

--- a/projects/rero/ng-core/src/lib/translate/i18n/de.json
+++ b/projects/rero/ng-core/src/lib/translate/i18n/de.json
@@ -28,7 +28,6 @@
   "it": "Italienisch",
   "less…": "Weniger…",
   "more…": "Weiteres…",
-  "results": "Ergebnisse",
   "search": "suchen",
   "should NOT be longer than {{maxLength}} characters": "should NOT be longer than {{maxLength}} characters",
   "should NOT be shorter than {{minLength}} characters": "should NOT be shorter than {{minLength}} characters",
@@ -42,5 +41,6 @@
   "should be equal to constant \"{{const}}\"": "should be equal to constant \"{{const}}\"",
   "should be multiple of ${{step}}": "should be multiple of ${{step}}",
   "should be null": "sollte null sein",
-  "the value is already taken": "der Wert ist bereits vergeben"
+  "the value is already taken": "der Wert ist bereits vergeben",
+  "{{ total }} results": "{{ total }} results"
 }

--- a/projects/rero/ng-core/src/lib/translate/i18n/en.json
+++ b/projects/rero/ng-core/src/lib/translate/i18n/en.json
@@ -28,7 +28,6 @@
   "it": "Italian",
   "less…": "less…",
   "more…": "more…",
-  "results": "results",
   "search": "search",
   "should NOT be longer than {{maxLength}} characters": "should NOT be longer than {{maxLength}} characters",
   "should NOT be shorter than {{minLength}} characters": "should NOT be shorter than {{minLength}} characters",
@@ -42,5 +41,6 @@
   "should be equal to constant \"{{const}}\"": "should be equal to constant \"{{const}}\"",
   "should be multiple of ${{step}}": "should be multiple of ${{step}}",
   "should be null": "should be null",
-  "the value is already taken": "the value is already taken"
+  "the value is already taken": "the value is already taken",
+  "{{ total }} results": "{{ total }} results"
 }

--- a/projects/rero/ng-core/src/lib/translate/i18n/en_US.json
+++ b/projects/rero/ng-core/src/lib/translate/i18n/en_US.json
@@ -28,7 +28,6 @@
   "it": "Italian",
   "less…": "less…",
   "more…": "more…",
-  "results": "results",
   "search": "search",
   "should NOT be longer than {{maxLength}} characters": "should NOT be longer than {{maxLength}} characters",
   "should NOT be shorter than {{minLength}} characters": "should NOT be shorter than {{minLength}} characters",
@@ -42,5 +41,6 @@
   "should be equal to constant \"{{const}}\"": "should be equal to constant \"{{const}}\"",
   "should be multiple of ${{step}}": "should be multiple of ${{step}}",
   "should be null": "should be null",
-  "the value is already taken": "the value is already taken"
+  "the value is already taken": "the value is already taken",
+  "{{ total }} results": "{{ total }} results"
 }

--- a/projects/rero/ng-core/src/lib/translate/i18n/fr.json
+++ b/projects/rero/ng-core/src/lib/translate/i18n/fr.json
@@ -28,7 +28,6 @@
   "it": "Italien",
   "less…": "moins…",
   "more…": "plus…",
-  "results": "résultats",
   "search": "rechercher",
   "should NOT be longer than {{maxLength}} characters": "Ne doit pas être plus long que {{maxLength}} caractères",
   "should NOT be shorter than {{minLength}} characters": "Ne doit pas être plus court que {{minLength}} caractères",
@@ -42,5 +41,6 @@
   "should be equal to constant \"{{const}}\"": "Doit être égal à la constante \"{{const}}\"",
   "should be multiple of ${{step}}": "Doit être un multiple de ${{step}}",
   "should be null": "doit être vide",
-  "the value is already taken": "cette valeur est déjà utilisée"
+  "the value is already taken": "cette valeur est déjà utilisée",
+  "{{ total }} results": "{{ total }} results"
 }

--- a/projects/rero/ng-core/src/lib/translate/i18n/it.json
+++ b/projects/rero/ng-core/src/lib/translate/i18n/it.json
@@ -28,7 +28,6 @@
   "it": "Italiano",
   "less…": "di meno…",
   "more…": "di più…",
-  "results": "risultati",
   "search": "ricerca",
   "should NOT be longer than {{maxLength}} characters": "should NOT be longer than {{maxLength}} characters",
   "should NOT be shorter than {{minLength}} characters": "should NOT be shorter than {{minLength}} characters",
@@ -42,5 +41,6 @@
   "should be equal to constant \"{{const}}\"": "should be equal to constant \"{{const}}\"",
   "should be multiple of ${{step}}": "should be multiple of ${{step}}",
   "should be null": "deve essere vuoto",
-  "the value is already taken": "il valore è già utilizzato"
+  "the value is already taken": "il valore è già utilizzato",
+  "{{ total }} results": "{{ total }} results"
 }


### PR DESCRIPTION
* Adds a configuration support to customize the number of results text.
* Adds a title on a search view when only one resource is displayed.
* Adds a new configuration to hide the title on the search page.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
