### PR TITLE
editor: fix translation

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.html
@@ -19,9 +19,10 @@
   <div  class="form-group">
     <label for="addField" translate>Add field</label>
     <input
-      id="#addField"
+      id="addField"
       [(ngModel)]="value"
       [typeahead]="typeaheadFields"
+      [typeaheadItemTemplate]="itemTemplate"
       typeaheadOptionField="name"
       (typeaheadOnSelect)="itemSelected($event)"
       class="form-control"
@@ -38,8 +39,12 @@
         (click)="showSelectedField(field.field)"
         class="btn btn-outline-secondary w-100 mb-1 btn-sm overflow-hidden"
       >
-        {{ field.field.templateOptions.label }}
+        {{ field.name | async }}
       </button>
     </li>
   </ul>
 </div>
+
+<ng-template #itemTemplate let-model="item">
+  {{ model.name | async }}
+</ng-template>

--- a/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.ts
@@ -17,7 +17,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { TypeaheadMatch } from 'ngx-bootstrap/typeahead/public_api';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { EditorService } from '../editor.service';
 
@@ -25,7 +25,7 @@ import { EditorService } from '../editor.service';
  * Type a head selection type
  */
 interface FormlyFieldConfigSelection {
-  name: string;
+  name: any;
   field: FormlyFieldConfig;
 }
 
@@ -62,9 +62,12 @@ export class AddFieldEditorComponent implements OnInit {
     // avoid duplicate when switching between page
     this._editorService.clearHiddenFields();
     this.typeaheadFields$ = this._editorService.hiddenFields$.pipe(
-      map( (fields: FormlyFieldConfig[]) => {
+      map((fields: FormlyFieldConfig[]) => {
         const value = fields.map(field => {
-          return {name: field.templateOptions.label, field};
+          const name = field.expressionProperties['templateOptions.label']
+          ? field.expressionProperties['templateOptions.label']
+          : of(field.templateOptions.label);
+          return { name, field };
         });
         return value;
       })


### PR DESCRIPTION
When setting up the translation, the processing of the options in the select menu was missing.
The translation of the labels is not done correctly on the long form when the user changes language.

* fixes translation of select menu.
* fixes translation of input field and button on the long form.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>