### PR TITLE
editor: fix 'oneOf' behaviour

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -341,11 +341,12 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
     if (
       !['object', 'multischema', 'array'].some(f => f === field.type)
     ) {
+      // TODO following line seems to raise an error with v5.9.0 of ngx-formly
       model = field.model[field.key];
     }
     model = removeEmptyValues(model);
     const modelEmpty = isEmpty(model);
-    if (!modelEmpty && (field.hide !== false)) {
+    if (!modelEmpty && (field.hide === true)) {
       setTimeout(() => {
         field.hide = false;
         this._editorService.removeHiddenField(field);


### PR DESCRIPTION
Fixes the behaviour of the editor with 'oneOf' schema property: for
example, when selecting 'organisation' as author, the value of 'type'
needed to be selected manually. Now the correct value of type is
selected automatically. A similar behaviour is noted for 'mode of
issuance' maintype and subtype.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>
Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

This PR is part of US1432 (task 1603)
https://tree.taiga.io/project/rero21-reroils/us/1432?milestone=268117
https://tree.taiga.io/project/rero21-reroils/task/1603?kanban-status=1224894

## How to test?

Needs https://github.com/rero/rero-ils/pull/1097 and https://github.com/rero/rero-ils-ui/pull/283
Login as a (system) librarian.
Go to the record editor.
Try several values for authors and mode of issuance. 
If you try to edit an existing record, you'll find that the values are not correct, except for the default ones. This is reported here: https://github.com/rero/rero-ils/issues/1102

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
