### PR TITLE
security: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9542,10 +9542,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash-es": {
       "version": "4.17.14",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "font-awesome": "^4.7.0",
     "handlebars": "^4.7.3",
     "kind-of": "^6.0",
+    "lodash": "^4.17.19",
     "lodash-es": "4.17.14",
     "minimist": ">=0.2.1",
     "moment": "^2.24.0",


### PR DESCRIPTION
* Upgrades `lodash` library to version equal or greater than 4.17.19.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>