### PR TITLE
editor: fix toggle switch issue

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.service.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.service.ts
@@ -43,7 +43,7 @@ export class EditorService {
    */
   setFocus(field: FormlyFieldConfig, scroll: boolean = false) {
     if (scroll === true && field.id)  {
-      const el = document.getElementById(field.id);
+      const el = document.getElementById(`field-${field.id}`);
       if (el != null) {
         // TODO : investigate why sometimes(often) the scroll isn't smooth...
         el.scrollIntoView({ behavior: 'smooth' });

--- a/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/object-type/object-type.component.html
@@ -29,7 +29,7 @@
 <!-- each object properties -->
 <div class="{{ getCssClass() }}">
   <ng-container *ngFor="let f of field.fieldGroup">
-    <div class="{{ getCssClass(f) }}" *ngIf="!f.hide" [id]="f.id">
+    <div class="{{ getCssClass(f) }}" *ngIf="!f.hide" [id]="'field-' + f.id">
       <!-- if the field is repeatable the title is rendered by the corresponding array -->
       <ng-container *ngIf="((!isParrentArray() && f.type === 'object') || f.type === 'array')">
         <!-- section header -->


### PR DESCRIPTION
* Prefixes the `id` attribute for fields with `field-`, to make the toggle switch work again.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>