### PR TITLE
editor: add ordered property for definitions

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -328,7 +328,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
           }
 
           // Add an horizontal wrapper
-          if (this._horizontalWrapperTypes.some(elem => elem === field.type)) {
+          if (this.longMode && this._horizontalWrapperTypes.some(elem => elem === field.type)) {
             field.wrappers = [
               ...(field.wrappers ? field.wrappers : []),
               'form-field-horizontal'

--- a/projects/rero/ng-core/src/lib/record/editor/utils.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/utils.ts
@@ -50,16 +50,22 @@ export function orderedJsonSchema(schema: any) {
       orderedJsonSchema(item);
     }
   }
-    // recursion for anyOf
+  // recursion for anyOf
   if (schema.anyOf) {
-    for (const item of schema.oneOf) {
-      orderedJsonSchema(schema.anyOf);
+    for (const item of schema.anyOf) {
+      orderedJsonSchema(item);
     }
   }
   // recursion for allOf
   if (schema.allOf) {
-    for (const item of schema.oneOf) {
-      orderedJsonSchema(schema.allOf);
+    for (const item of schema.allOf) {
+      orderedJsonSchema(item);
+    }
+  }
+  // recursion for definitions
+  if (schema.definitions) {
+    for (const property of Object.keys(schema.definitions)) {
+      orderedJsonSchema(schema.definitions[property]);
     }
   }
   return schema;
@@ -87,7 +93,7 @@ export function resolveRefs(data: any) {
     for (const key of Object.keys(data)) {
       const value = resolveRefs(data[key]);
       if (key === '$ref') {
-        newObject.pid =  extractIdOnRef(value);
+        newObject.pid = extractIdOnRef(value);
       } else {
         newObject[key] = value;
       }


### PR DESCRIPTION
* Adds ordered properties for JSONSchema definitions.
* Fixes ordered properties for JSONSchema oneOf, anyOf.
* Sets horizontal labels only for the long mode editor.

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
