### PR TITLE
editor: implement specific id attribute for formly fields

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -17,8 +17,8 @@
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormlyExtension, FormlyFieldConfig } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, isObservable } from 'rxjs';
 import sha256 from 'crypto-js/sha256';
+import { BehaviorSubject, isObservable } from 'rxjs';
 
 /**
  * Add onPopulate hook at the field level.
@@ -32,7 +32,6 @@ export function onPopulateHook(field: FormlyFieldConfig) {
   }
 }
 
-
 export const hooksFormlyExtension: FormlyExtension = {
 
   /**
@@ -45,6 +44,38 @@ export const hooksFormlyExtension: FormlyExtension = {
   onPopulate: onPopulateHook
 };
 
+/**
+ * Add a custom id before populating the form
+ * @param field formly field config
+ */
+export function prePopulateFieldIdGenerator(field: FormlyFieldConfig) {
+  if (field.key) {
+    field.id = getKey(field);
+  }
+ }
+
+/**
+ * Call the field id generator
+ */
+export const fieldIdGenerator: FormlyExtension = {
+   prePopulate: prePopulateFieldIdGenerator
+};
+
+/**
+ * Create an id html attribute by joining field and parents keys
+ * @param field formly field config
+ * @returns array - keys to create the id html attribute
+ */
+export function getKey(field: any): string {
+  let parentKey = null;
+  if (field.parent != null && field.parent.key != null) {
+    parentKey = getKey(field.parent);
+  }
+  if (parentKey != null) {
+    return [parentKey, field.key].join('-');
+  }
+  return field.key;
+}
 
 export class TranslateExtension {
 

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -35,7 +35,7 @@ import { AddFieldEditorComponent } from './editor/add-field-editor/add-field-edi
 import { ArrayTypeComponent } from './editor/array-type/array-type.component';
 import { DropdownLabelEditorComponent } from './editor/dropdown-label-editor/dropdown-label-editor.component';
 import { EditorComponent } from './editor/editor.component';
-import { hooksFormlyExtension, registerTranslateExtension } from './editor/extensions';
+import { hooksFormlyExtension, registerTranslateExtension, fieldIdGenerator } from './editor/extensions';
 import { HorizontalWrapperComponent } from './editor/horizontal-wrapper/horizontal-wrapper.component';
 import { MultiSchemaTypeComponent } from './editor/multischema/multischema.component';
 import { ObjectTypeComponent } from './editor/object-type/object-type.component';
@@ -92,7 +92,10 @@ import { RecordSearchResultDirective } from './search/result/record-search-resul
     PaginationModule.forRoot(),
     BsDatepickerModule.forRoot(),
     FormlyModule.forRoot({
-      extensions: [{ name: 'hooks', extension: hooksFormlyExtension }],
+      extensions: [
+        { name: 'hooks', extension: hooksFormlyExtension },
+        { name: 'field-id-generator', extension: fieldIdGenerator }
+      ],
       types: [
         { name: 'string', extends: 'input' },
         {


### PR DESCRIPTION
* Adds an extension to set specific id attributes to formly fields in order to select them more easily with Cypress.

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

https://tree.taiga.io/project/rero21-reroils/task/1622?kanban-status=1224894
Source: 
* https://github.com/ngx-formly/ngx-formly/issues/1150#issuecomment-416239430
* https://github.com/ngx-formly/ngx-formly/issues/1624#issuecomment-502771903

## How to test?

Go to an editor (documents, items) and check that the fields have an id attribute with joined keys.
Check the elements of arrays.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
