### PR TITLE
template: add id html attribute for cypress usage

### DIFF
--- a/projects/rero/ng-core/src/lib/dialog/dialog.component.html
+++ b/projects/rero/ng-core/src/lib/dialog/dialog.component.html
@@ -20,11 +20,13 @@
 <div class="modal-body" [innerHtml]="body|nl2br"></div>
 <div class="modal-footer">
   <button
+  id="modal-cancel-button"
     type="button"
     class="btn btn-light"
     (click)="decline()"
   >{{ cancelTitleButton | translate }}</button>
   <button
+    id="modal-confirm-button"
     type="button"
     class="btn btn-primary"
     (click)="confirm()"

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.html
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.html
@@ -18,18 +18,18 @@
   <div class="alert alert-danger" *ngIf="error">{{ error | translate }}</div>
   <div class="float-right ml-4 mt-2 mb-4" *ngIf="record && adminMode.can">
       <a href class="btn btn-sm btn-primary" [routerLink]="['../../edit', record.metadata.pid]"
-          *ngIf="updateStatus && updateStatus.can">
+          *ngIf="updateStatus && updateStatus.can" id="detail-edit-button">
           <i class="fa fa-pencil"></i>
           {{ 'Edit' | translate }}
       </a>
       <ng-container *ngIf="deleteStatus">
-          <button class="btn btn-sm btn-outline-danger ml-1" [title]="'Delete'|translate"
+          <button id ="detail-delete-button" class="btn btn-sm btn-outline-danger ml-1" [title]="'Delete'|translate"
               (click)="deleteRecord(record)" *ngIf="deleteStatus.can; else deleteMessageLink">
               <i class="fa fa-trash"></i>
               {{ 'Delete' | translate }}
           </button>
           <ng-template #deleteMessageLink>
-              <button class="btn btn-sm btn-outline-danger ml-1 disabled" [title]="'Delete'|translate"
+              <button id ="detail-delete-button"  class="btn btn-sm btn-outline-danger ml-1 disabled" [title]="'Delete'|translate"
                   (click)="showDeleteMessage(deleteStatus.message)" *ngIf="deleteStatus.message">
                   <i class="fa fa-trash mr-1"></i>{{ 'Delete' | translate }}
               </button>
@@ -38,5 +38,5 @@
     </div>
     <ng-template ngCoreRecordDetail></ng-template>
     <hr class="my-4">
-    <button class="btn btn-link" (click)="goBack()">&laquo; {{ 'Back' | translate }}</button>
+    <button id="detail-back-button" class="btn btn-link" (click)="goBack()">&laquo; {{ 'Back' | translate }}</button>
 </div>

--- a/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.html
@@ -35,8 +35,9 @@
     </small>
   </div>
   <ul class="list-unstyled">
-    <li *ngFor="let field of typeaheadFields">
+    <li *ngFor="let field of typeaheadFields; let i = index">
       <button *ngIf="isFieldEssential(field)"
+        id="{{'add-field-' + i}}"
         (click)="showSelectedField(field)"
         class="btn btn-outline-secondary w-100 mb-1 text-truncate btn-sm"
       >

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -57,6 +57,7 @@
       <div class="mt-4 float-right">
         <!-- submit button -->
         <button
+          id="editor-delete-button"
           type="button"
           (click)="cancel()"
           class="btn btn-outline-danger btn-sm mr-1"
@@ -65,6 +66,7 @@
           {{ 'Cancel' | translate }}
         </button>
         <button
+          id="editor-save-button"
           type="submit"
           class="btn btn-primary btn-sm"
           [disabled]="!form.valid"

--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -68,11 +68,17 @@ export const fieldIdGenerator: FormlyExtension = {
  */
 export function getKey(field: any): string {
   let parentKey = null;
-  if (field.parent != null && field.parent.key != null) {
+
+  if (field.parent != null) {
     parentKey = getKey(field.parent);
   }
+
   if (parentKey != null) {
-    return [parentKey, field.key].join('-');
+    let newId = parentKey;
+    if (field.key != null) {
+      newId = [parentKey, field.key].join('-');
+    }
+    return newId;
   }
   return field.key;
 }

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -50,18 +50,18 @@
         <strong>{{ resultsText }}</strong>
       </div>
       <div class="col ml-auto text-right">
-        <a class="btn btn-primary" routerLink="new" *ngIf="adminMode.can && addStatus.can">
+        <a id="search-add-button" class="btn btn-primary" routerLink="new" *ngIf="adminMode.can && addStatus.can">
           <i class="fa fa-plus mr-0 mr-sm-1"></i>
           <span class="d-none d-sm-inline">{{ 'Add' | translate }}</span>
         </a>
-        <a role="button" class="btn btn-outline-primary ml-2" *ngIf="exportFormats && exportFormats.length == 1"
+        <a id="search-export-button" role="button" class="btn btn-outline-primary ml-2" *ngIf="exportFormats && exportFormats.length == 1"
            [class.disabled]="total === 0"
            [href]="getExportFormatUrl(exportFormats[0].format)" >
           <i class="fa fa-download mr-1"></i> {{ 'Export as' | translate }} {{ exportFormats[0].label }}
         </a>
         <div class="btn-group ml-2" dropdown *ngIf="exportFormats && exportFormats.length > 1">
           <button
-            id="button-export-basic"
+            id="search-export-button-basic"
             dropdownToggle
             [disabled]="total === 0"
             type="button"

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
@@ -15,17 +15,17 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <div class="float-right ml-5 mb-2" *ngIf="adminMode.can">
-    <a href class="btn btn-link p-0 ml-2" [title]="'Edit'|translate" routerLink="edit/{{ record.metadata.pid }}"
+    <a href id="result-edit-button" class="btn btn-link p-0 ml-2" [title]="'Edit'|translate" routerLink="edit/{{ record.metadata.pid }}"
         *ngIf="updateStatus && updateStatus.can">
         <i class="fa fa-pencil"></i>
     </a>
     <span class="ml-2" *ngIf="deleteStatus">
-        <button class="btn btn-link p-0" [title]="'Delete'|translate" (click)="deleteRecord(record.metadata.pid)"
+        <button id="result-delete-button" class="btn btn-link p-0" [title]="'Delete'|translate" (click)="deleteRecord(record.metadata.pid)"
             *ngIf="deleteStatus.can; else deleteMessageLink">
             <i class="fa fa-trash"></i>
         </button>
         <ng-template #deleteMessageLink>
-            <button class="btn btn-link p-0 text-muted" [title]="'Delete'|translate"
+            <button id="result-delete-button" class="btn btn-link p-0 text-muted" [title]="'Delete'|translate"
                 (click)="showDeleteMessage(deleteStatus.message)" *ngIf="deleteStatus.message">
                 <i class="fa fa-trash"></i>
             </button>


### PR DESCRIPTION
* Adds id html attributes in templates for cypress usage.
* Corrects the method to inject custom id in the editor to be functional
with oneOf fields (issuance, authors).

Co-Authored-by: Alicia Zangger <alicia.zangger@rero.ch>

## Why are you opening this PR?

To adapt the templates for tests with cypress.

## How to test?

Code review only

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
