### PR TITLE
editor: fix hidden field with value from the model

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/add-field-editor/add-field-editor.component.html
@@ -15,7 +15,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <!-- from ngx-boostrap -->
-<div class="w-100" *ngIf="typeaheadFields">
+<div class="w-100" *ngIf="hiddenFields$ | async as hiddenFields">
   <div  class="form-group">
     <label for="addField" translate>Add field</label>
     <input
@@ -28,15 +28,15 @@
       (typeaheadOnSelect)="itemSelected($event)"
       class="form-control"
       typeaheadMinLength="0"
-      [disabled]="typeaheadFields.length === 0"
+      [disabled]="hiddenFields.length < 1"
     />
     <small id="addFieldHelp" class="form-text text-muted" translate>
       Press space for all.
     </small>
   </div>
   <ul class="list-unstyled">
-    <li *ngFor="let field of typeaheadFields; let i = index">
-      <button *ngIf="isFieldEssential(field)"
+    <li *ngFor="let field of essentialFields$ | async ; let i = index ">
+      <button
         id="{{'add-field-' + i}}"
         (click)="showSelectedField(field)"
         class="btn btn-outline-secondary w-100 mb-1 text-truncate btn-sm"

--- a/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/array-type/array-type.component.ts
@@ -47,7 +47,7 @@ export class ArrayTypeComponent extends FieldArrayType implements OnInit {
     this.isChildrenObject = this.field.fieldArray.type === 'object';
     this.isChildrenArray = this.field.fieldArray.type === 'array';
 
-    // reset the number of elements in the array when the array id hidden
+    // reset the number of elements in the array when the array is hidden
     this.field.options.fieldChanges.subscribe(changes => {
       const minItems = this.field.templateOptions.minItems ? this.field.templateOptions.minItems : 0;
       if (
@@ -61,12 +61,9 @@ export class ArrayTypeComponent extends FieldArrayType implements OnInit {
         // number of elements to remove
         const numberOfItemsToRemove = this.field.fieldGroup.length - minItems;
         // remove the extra elements
-        // force removing the elements in the next event loop else this cause errors when removing multiple values
-        setTimeout(() => {
-          for (let i = 0; i < numberOfItemsToRemove; i++) {
-            this.remove(0);
-          }
-        });
+        for (let i = 0; i < numberOfItemsToRemove; i++) {
+          this.remove(0);
+        }
       }
     });
   }

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div *ngIf="fields" class="row editor">
+<div class="row editor">
   <!-- add fields section -->
   <div *ngIf="longMode" class="col-md-3 col-xl-2 bd-sidebar">
     <ng-core-editor-add-field-editor
@@ -43,7 +43,6 @@
       class="col"
       [formGroup]="form"
       (ngSubmit)="submit($event)"
-      *ngIf="fields"
     >
       <!-- ngx-formly -->
       <formly-form

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -129,8 +129,13 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
    * @param changes: the changed properties
    */
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.model && !changes.model.isFirstChange) { // Model has changed
+    if (changes.model && !changes.model.isFirstChange()) { // Model has changed
       this._setModel(changes.model.currentValue);
+      // needed to select the right value for existing data in the multi select
+      // components such as oneOf
+      if (this.schema) {
+        this.setSchema(this.schema);
+      }
     }
   }
 
@@ -306,6 +311,8 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
     // reorder all object properties
     this.schema = orderedJsonSchema(schema);
     this.options = {};
+    // remove hidden field list in case of a previous setSchema call
+    this._editorService.clearHiddenFields();
 
     // form configuration
     const fields = [
@@ -378,16 +385,12 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
     model = removeEmptyValues(model);
     const modelEmpty = isEmpty(model);
     if (!modelEmpty && (field.hide === true)) {
-      setTimeout(() => {
         field.hide = false;
         this._editorService.removeHiddenField(field);
-      });
     }
     if (modelEmpty && (field.templateOptions.hide === true && field.hide === undefined)) {
-      setTimeout(() => {
         field.hide = true;
         this._editorService.addHiddenField(field);
-      });
     }
   }
 
@@ -451,11 +454,9 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
    * Populate the field to add to the TOC
    */
   getTocFields() {
-    setTimeout(() => {
       if (this.fields && this.fields.length > 0) {
         this.tocFields = this.fields[0].fieldGroup.filter(f => f.hide !== true);
       }
-    });
   }
 
   /**


### PR DESCRIPTION
Some fields containing values given with the input model should be visible
after the editor initializations. This is not the case with a recent version of
ngx formly. This is due to the use of bad hack `setTimeout` at several
places in the code. As ngx formly made the think cleaner these hacks have
been removed.

- Cleans hidden field list at the component destruction instead of
initialization.
- Removes the extra values in an array when the corresponding field is
hidden only when the values are reset.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Some fields containing data are not displayed when a record is imported from an external source such as BNF in the `rero-ils-ui` project.

## How to test?

- Link the library to the `rero-ils-ui` start the admin server, import a record from the BNF containing a `dimensions` value. This field should not be hidden. Check that not error is present in the console.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
