### PR TITLE
editor: add a typeahead component

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -320,12 +320,13 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
           const formOptions = jsonSchema.form;
 
           if (formOptions) {
-            this.setSimpleOptions(field, formOptions);
-            this.setValidation(field, formOptions);
-            this.setRemoteSelectOptions(field, formOptions);
+            this._setSimpleOptions(field, formOptions);
+            this._setValidation(field, formOptions);
+            this._setRemoteSelectOptions(field, formOptions);
+            this._setRemoteTypeahead(field, formOptions);
           }
           if (this.longMode === true) {
-            // show the field if the model contains a value usefull for edition
+            // show the field if the model contains a value useful for edition
             field.hooks = {
               ...field.hooks,
               onPopulate: (f: any) => {
@@ -472,7 +473,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
    * @param field formly field config
    * @param formOptions JSONSchema object
    */
-  private setRemoteSelectOptions(
+  private _setRemoteSelectOptions(
     field: FormlyFieldConfig,
     formOptions: JSONSchema7
   ) {
@@ -506,11 +507,29 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   /**
+   * Store the remote typeahead options.
+   * @param field formly field config
+   * @param formOptions JSONSchema object
+   */
+  private _setRemoteTypeahead(
+    field: FormlyFieldConfig,
+    formOptions: JSONSchema7
+  ) {
+    if (formOptions.remoteTypeahead && formOptions.remoteTypeahead.type) {
+      field.type = 'remoteTypeahead';
+      field.templateOptions = {
+        ...field.templateOptions,
+        ...{remoteTypeahead: formOptions.remoteTypeahead}
+      };
+    }
+  }
+
+  /**
    *
    * @param field formly field config
    * @param formOptions JSONSchema object
    */
-  private setValidation(field: FormlyFieldConfig, formOptions: JSONSchema7) {
+  private _setValidation(field: FormlyFieldConfig, formOptions: JSONSchema7) {
     if (formOptions.validation) {
       // custom validation messages
       const messages = formOptions.validation.messages;
@@ -608,7 +627,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
    * @param field formly field config
    * @param formOptions JSONSchema object
    */
-  private setSimpleOptions(field: FormlyFieldConfig, formOptions: JSONSchema7) {
+  private _setSimpleOptions(field: FormlyFieldConfig, formOptions: JSONSchema7) {
     // ngx formly standard options
     // hide a field at startup
     if (formOptions.hide === true) {

--- a/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.component.html
@@ -1,0 +1,42 @@
+<!--
+ RERO angular core
+ Copyright (C) 2020 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!-- input field: empty ref -->
+<ng-container *ngIf="formControl">
+  <div *ngIf="!formControl.value; else metadataTemplate" class="input-group">
+    <input class="form-control" [(ngModel)]="search" autocomplete="off" [typeaheadAsync]="true"
+      [typeahead]="suggestions$" (typeaheadLoading)="changeTypeaheadLoading($event)"
+      (typeaheadOnSelect)="typeaheadOnSelect($event)" [typeaheadWaitMs]="300" [typeaheadMinLength]="2"
+      [typeaheadGroupField]="groupField" typeaheadOptionField="label" />
+    <div class="input-group-append">
+      <span class="input-group-text" id="{field.id}-search">
+        <i *ngIf="!typeaheadLoading" class="fa fa-search"></i>
+        <i *ngIf="typeaheadLoading" class="fa fa-spinner fa-spin"></i>
+      </span>
+    </div>
+  </div>
+
+  <!-- text representation of the value in ref -->
+  <ng-template #metadataTemplate>
+    <div *ngIf="valueAsHTML$ | async as valueAsHTML">
+      <div class="d-inline" [innerHTML]="valueAsHTML"></div>
+      <button class="btn btn-link text-secondary btn-sm" type="button" (click)="clear()">
+        <i class="fa fa-trash"></i>
+      </button>
+    </div>
+  </ng-template>
+</ng-container>

--- a/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.component.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * RERO angular core
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { CoreModule } from '../../../core.module';
+import { RecordModule } from '../../record.module';
+import { RemoteTypeaheadComponent } from './remote-typeahead.component';
+
+
+describe('RemoteTypeaheadComponent', () => {
+  let component: RemoteTypeaheadComponent;
+  let fixture: ComponentFixture<RemoteTypeaheadComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CoreModule,
+        RecordModule,
+        HttpClientTestingModule,
+        TranslateModule.forRoot({}),
+        ReactiveFormsModule
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RemoteTypeaheadComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // TODO: enable later
+  // it('should create', () => {
+  //   expect(component).toBeTruthy();
+  // });
+});

--- a/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.component.ts
@@ -1,0 +1,136 @@
+/*
+ * RERO angular core
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
+import { Observable, Observer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { RemoteTypeaheadService } from './remote-typeahead.service';
+
+
+@Component({
+  selector: 'ng-core-remote-typeahead',
+  templateUrl: './remote-typeahead.component.html'
+})
+export class RemoteTypeaheadComponent extends FieldType implements OnInit {
+
+  /** Input search string */
+  search: string;
+
+  /** Loading data */
+  typeaheadLoading: boolean;
+
+  /** Observable on Suggestions Metadata */
+  suggestions$: Observable<Array<SuggestionMetadata>>;
+
+  /** Template representation of the formControl value. */
+  valueAsHTML$: Observable<string>;
+
+  /** Number of result in suggestions list */
+  private _numberOfSuggestions = 10;
+
+  /** Remote Typeahead options from the JONSchema */
+  private get _rtOptions(): object {
+    return this.field.templateOptions.remoteTypeahead;
+  }
+
+  /**
+   * Constructor
+   * @param _remoteTypeaheadService - RemoteTypeaheadService
+   */
+  constructor(
+    private _remoteTypeaheadService: RemoteTypeaheadService
+  ) {
+    super();
+  }
+
+  /** Init */
+  ngOnInit() {
+
+    // get the list of suggestions based on input search changes
+    this.suggestions$ = new Observable((observer: Observer<string>) => {
+      observer.next(this.search);
+    }).pipe(
+      switchMap((query: string) => {
+        return this._remoteTypeaheadService.getSuggestions(this._rtOptions, query, this._numberOfSuggestions);
+      })
+    );
+
+    // get the template version of the formControl value
+    this.valueAsHTML$ = new Observable((observer: Observer<string>) => {
+      observer.next(this.formControl.value);
+    }).pipe(
+      switchMap((value: string) => {
+        return this._remoteTypeaheadService.getValueAsHTML(this._rtOptions, value);
+      })
+    );
+  }
+
+  /**
+   * Return the group field when the suggestion as grouped by category.
+   * @returns string - the name of the field in suggestion list containing the group category. null for disabled.
+   */
+  get groupField(): string | null {
+    const enableGF = this._remoteTypeaheadService.enableGroupField(this._rtOptions);
+    return enableGF ? 'group' : null;
+  }
+
+  /**
+   * Change Typeahead loading.
+   * @param e boolean
+   */
+  changeTypeaheadLoading(e: boolean): void {
+    this.typeaheadLoading = e;
+  }
+
+  /**
+   * Set the field value with the selected suggestion.
+   * @param e - TypeaheadMatch
+   */
+  typeaheadOnSelect(e: TypeaheadMatch): void {
+    if (e.item.value != null) {
+      this.formControl.setValue(e.item.value);
+    } else {
+      this.formControl.get('$ref').reset();
+    }
+  }
+
+  /**
+   * Render the string representation of the $ref.
+   * @returns string - html to inject in the template.
+   */
+  getValueAsHTML(): Observable<string> {
+    return this._remoteTypeaheadService.getValueAsHTML(this._rtOptions, this.formControl.value);
+  }
+
+  /**
+   * Clear current value
+   */
+  clear(): void {
+    this.search = null;
+    this.formControl.reset();
+    this.field.focus = true;
+  }
+}
+
+/** Suggestion Metadata Interface */
+export interface SuggestionMetadata {
+  label: string;
+  value: string;
+  group?: string;
+}

--- a/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.service.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.service.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * RERO angular core
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ApiService } from '../../../api/api.service';
+import { RecordService } from '../../record.service';
+import { RemoteTypeaheadService } from './remote-typeahead.service';
+import { TranslateModule } from '@ngx-translate/core';
+
+
+describe('RemoteTypeaheadService', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      HttpClientTestingModule,
+      TranslateModule.forRoot()
+    ],
+    providers: [
+      RecordService,
+      ApiService
+    ]
+  }));
+  it('should be created', () => {
+    const service: RemoteTypeaheadService = TestBed.get(RemoteTypeaheadService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.service.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/remote-typeahead/remote-typeahead.service.ts
@@ -1,0 +1,99 @@
+/*
+ * RERO angular core
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Injectable } from '@angular/core';
+import { RecordService } from '../../record.service';
+import { map } from 'rxjs/operators';
+import { of, Observable } from 'rxjs';
+import { ApiService } from '../../../api/api.service';
+import { SuggestionMetadata } from './remote-typeahead.component';
+import { Record } from '../../record';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RemoteTypeaheadService {
+
+  /** Constructor.
+   * @param _recordService - RecordService
+   * @param _apiService - APIService
+   */
+  constructor(
+    protected _recordService: RecordService,
+    protected _apiService: ApiService
+  ) { }
+
+  /**
+   * Convert the input value (i.e. $ref url) into a template html code.
+   * @param options - remote typeahead options
+   * @param value - formControl value i.e. $ref value
+   * @returns Observable of string - html template representation of the value.
+   */
+  getValueAsHTML(options, value: string): Observable<string> {
+    const url = value.split('/');
+    const pid = url.pop();
+    return this._recordService
+      .getRecord(options.type, pid, 1)
+      .pipe(
+        map(result => {
+          return result.metadata[options.field];
+        }),
+        map(v => `<strong>${v}</strong>`)
+      );
+  }
+
+  /**
+   * Enable/disable the group field functionality in the ngx-bootstrap typeahead.
+   * @param options - remote typeahead options
+   * @returns true if the group field typeahead should be enabled
+   */
+  enableGroupField(options: any): boolean {
+    return options.enableGroupField;
+  }
+
+  /**
+   * Get the suggestions list given a search query.
+   * @param options - remote typeahead options
+   * @param query - search query to retrieve the suggestions list
+   * @param numberOfSuggestions - the max number of suggestion to return
+   * @returns - an observable of the list of suggestions.
+   */
+  getSuggestions(options: any, query: string, numberOfSuggestions: number): Observable<Array<SuggestionMetadata>> {
+    if (!query) {
+      return of([]);
+    }
+    return this._recordService
+      .getRecords(options.type, `${options.field}:${query}` , 1, numberOfSuggestions)
+      .pipe(
+        map((results: Record) => {
+          const names = [];
+          if (!results) {
+            return [];
+          }
+          results.hits.hits.map((hit: any) => {
+            names.push({
+              label: hit.metadata[options.field],
+              value: this._apiService.getRefEndpoint(options.type, hit.metadata.pid)
+              // add a group field to group the results
+              // group: 'book'
+            });
+          });
+          return names;
+        })
+      );
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -52,6 +52,7 @@ import { RecordSearchComponent } from './search/record-search.component';
 import { JsonComponent } from './search/result/item/json.component';
 import { RecordSearchResultComponent } from './search/result/record-search-result.component';
 import { RecordSearchResultDirective } from './search/result/record-search-result.directive';
+import { RemoteTypeaheadComponent } from './editor/remote-typeahead/remote-typeahead.component';
 
 @NgModule({
   declarations: [
@@ -78,7 +79,8 @@ import { RecordSearchResultDirective } from './search/result/record-search-resul
     BucketsComponent,
     HorizontalWrapperComponent,
     AggregationSliderComponent,
-    SelectWithSortTypeComponent
+    SelectWithSortTypeComponent,
+    RemoteTypeaheadComponent
   ],
   imports: [
     CoreModule,
@@ -122,7 +124,8 @@ import { RecordSearchResultDirective } from './search/result/record-search-resul
         { name: 'object', component: ObjectTypeComponent },
         { name: 'multischema', component: MultiSchemaTypeComponent },
         { name: 'datepicker', component: DatepickerTypeComponent },
-        { name: 'selectWithSort', component: SelectWithSortTypeComponent }
+        { name: 'selectWithSort', component: SelectWithSortTypeComponent },
+        { name: 'remoteTypeahead', component: RemoteTypeaheadComponent }
       ],
       wrappers: [
         { name: 'toggle-switch', component: ToggleWrapperComponent },

--- a/projects/rero/ng-core/src/public-api.ts
+++ b/projects/rero/ng-core/src/public-api.ts
@@ -62,3 +62,5 @@ export * from './lib/utils/utils';
 export * from './lib/validator/time.validator';
 export * from './lib/validator/unique.validator';
 export * from './lib/error/error.component';
+export * from './lib/record/editor/remote-typeahead/remote-typeahead.service';
+export * from './lib/record/editor/remote-typeahead/remote-typeahead.component';


### PR DESCRIPTION
* Adds a new typeahead component to be able to search a list of suggestion
  using the backend.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
