### PR TITLE
wrapper : remove description under toggle wrapper.

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/toggle-wrapper/toggle-wrappers.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/toggle-wrapper/toggle-wrappers.component.ts
@@ -27,7 +27,6 @@ import { isEmpty, removeEmptyValues } from '../utils';
           <input class="custom-control-input" type="checkbox" id="toggle-switch" (change)="toggle($event)" [checked]="tsOptions.enabled">
           <label class="custom-control-label" for="toggle-switch" [tooltip]="tsOptions.description">{{ tsOptions.label }}</label>
         </div>
-        <small class="form-text text-muted" *ngIf="tsOptions.description">{{ tsOptions.description }}</small>
       </div>
       <ng-container *ngIf="tsOptions.enabled" #fieldComponent></ng-container>
     </div>


### PR DESCRIPTION
As the description is already display as tooltip on toggle label, this
commit removes the description under the toggle button.

Co-Authored-by : Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
