### PR TITLE
editor: avoid loading the whole bootstrap library.

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.scss
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.scss
@@ -14,7 +14,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-@import "node_modules/bootstrap/scss/bootstrap";
+@import "node_modules/bootstrap/scss/functions";
+@import "node_modules/bootstrap/scss/mixins";
+@import "node_modules/bootstrap/scss/variables";
 .editor {
   .bd-toc {
     @supports (position: sticky) {


### PR DESCRIPTION
Instead of loading the whole Bootstrap library, only load functions, mixins and variables, to avoid that local styles of the editor override the main styles of the application.

* Removes global boostrap inclusion.
* Adds boostrap's functions, mixins and variables.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>