### PR TITLE
editor: fix options groups for select boxes

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -19,6 +19,7 @@ import { FormlyExtension, FormlyFieldConfig } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
 import sha256 from 'crypto-js/sha256';
 import { BehaviorSubject, isObservable } from 'rxjs';
+import { SelectOption } from './interfaces';
 
 /**
  * Add onPopulate hook at the field level.
@@ -176,10 +177,16 @@ export class TranslateExtension {
   private _translateOptions(options: any) {
     const selectOptions = [];
     options.forEach((element: any) => {
-      selectOptions.push({
+      const translatedOption: SelectOption = {
         label: this._translate.instant(element.label),
         value: element.value
-      });
+      };
+
+      if (element.group) {
+        translatedOption.group = element.group;
+      }
+
+      selectOptions.push(translatedOption);
     });
     return selectOptions;
   }


### PR DESCRIPTION
When options labels are translated for select boxes, the group optionally present was dropped. This PR re-inject the group to keep options grouped.

* Adds `group` property after option is translated, if initially present.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>