### PR TITLE
records: search on specific fields

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -257,7 +257,17 @@ const routes: Routes = [
           itemHeaders: {
             'Content-Type': 'application/rero+json'
           },
-          filesEnabled: true
+          filesEnabled: true,
+          searchFields: [
+            {
+              label: 'Full-text',
+              path: 'fulltext'
+            },
+            {
+              label: 'Main title',
+              path: 'title.mainTitle.value'
+            }
+          ]
         },
         {
           key: 'organisations',

--- a/projects/rero/ng-core/src/lib/record/record.ts
+++ b/projects/rero/ng-core/src/lib/record/record.ts
@@ -43,3 +43,13 @@ export interface File {
   showInfo: boolean;
   showChildren: boolean;
 }
+
+/**
+ * Interface representing a search property, on which we can do a specific search
+ * with query string like: `q=title:query`.
+ */
+export interface SearchField {
+  label: string;
+  path: string;
+  selected?: boolean;
+}

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -104,7 +104,31 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-3" *ngIf="aggregations && aggregations.length">
+      <div class="col-sm-3" *ngIf="(aggregations && aggregations.length) || searchFields.length > 0">
+        <div class="btn-group btn-block mb-3" dropdown *ngIf="searchFields.length > 0 && q">
+          <button
+              class="btn btn-outline-primary btn-sm text-left"
+              [ngClass]="{ active: selectedSearchFields[0] === searchFields[0] }"
+              *ngIf="searchFields.length === 1; else fieldsDropdown"
+              (click)="searchInField(searchFields[0])"
+          >
+              {{ 'Search in' | translate }} {{ searchFields[0].label | lowercase }}
+          </button>
+          <ng-template #fieldsDropdown>
+            <button dropdownToggle type="button" class="btn btn-outline-primary btn-sm rounded text-left" [ngClass]="{ active: selectedSearchFields.length > 0 }">
+              {{ 'Search in' | translate }}
+              <span>{{ selectedSearchFields.length > 0 ? ' "' + selectedSearchFields[0].label + '"' : '...' }}</span>
+            </button>
+            <ul *dropdownMenu class="dropdown-menu" role="menu">
+              <li *ngFor="let field of searchFields">
+                <a href="#" class="dropdown-item" [ngClass]="{ 'active': field.selected }"
+                  (click)="$event.preventDefault(); searchInField(field)">
+                  {{ field.label }}
+                </a>
+              </li>
+            </ul>
+          </ng-template>
+        </div>
         <div *ngFor="let item of aggregations">
           <ng-core-record-search-aggregation
             [aggregation]="item"


### PR DESCRIPTION
This PR give the possibility to configure search fields. When a field (or more) is selected, the search is done on this field only, this is exclusive.

* Adds configuration for specific fields in routing.
* Adds an interface representing a search field.
* Displays the list of search fields above the aggregations filters.
* Builds a custom query if specific fields are selected.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>