### PR TITLE
editor: add schema example in the demo application

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -23,6 +23,7 @@ import { Observable, of } from 'rxjs';
 import { HomeComponent } from './home/home.component';
 import { DetailComponent } from './record/document/detail/detail.component';
 import { DocumentComponent } from './record/document/document.component';
+import { EditorComponent } from './record/editor/editor.component';
 import { RouteService } from './routes/route.service';
 
 /**
@@ -211,6 +212,10 @@ const routes: Routes = [
   {
     path: '',
     component: HomeComponent
+  },
+  {
+    path: 'editor',
+    component: EditorComponent
   },
   {
     matcher: documentsMatcher,

--- a/projects/ng-core-tester/src/app/app.module.ts
+++ b/projects/ng-core-tester/src/app/app.module.ts
@@ -20,17 +20,18 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { CoreConfigService, RecordModule, TranslateLoader } from '@rero/ng-core';
-import { BsLocaleService } from 'ngx-bootstrap/datepicker';
-import { CollapseModule } from 'ngx-bootstrap/collapse';
-import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { defineLocale } from 'ngx-bootstrap/chronos';
+import { CollapseModule } from 'ngx-bootstrap/collapse';
+import { BsLocaleService } from 'ngx-bootstrap/datepicker';
 import { deLocale, enGbLocale, frLocale, itLocale } from 'ngx-bootstrap/locale';
+import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { AppConfigService } from './app-config.service';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HomeComponent } from './home/home.component';
 import { DetailComponent } from './record/document/detail/detail.component';
 import { DocumentComponent } from './record/document/document.component';
+import { EditorComponent } from './record/editor/editor.component';
 import { SearchBarComponent } from './search-bar/search-bar.component';
 
 @NgModule({
@@ -39,7 +40,8 @@ import { SearchBarComponent } from './search-bar/search-bar.component';
     DocumentComponent,
     HomeComponent,
     DetailComponent,
-    SearchBarComponent
+    SearchBarComponent,
+    EditorComponent
   ],
   imports: [
     BrowserModule,

--- a/projects/ng-core-tester/src/app/record/editor/editor.component.html
+++ b/projects/ng-core-tester/src/app/record/editor/editor.component.html
@@ -1,0 +1,27 @@
+<!--
+ RERO angular core
+ Copyright (C) 2020 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<div class="card mb-3">
+  <div class="card-header">
+    Model
+  </div>
+  <div class="card-body">
+    <pre>{{ model | json }}</pre>
+  </div>
+</div>
+<ng-core-editor [schema]="schema" [editorSettings]="editorSettings" (modelChange)="modelChanged($event)">
+</ng-core-editor>

--- a/projects/ng-core-tester/src/app/record/editor/editor.component.spec.ts
+++ b/projects/ng-core-tester/src/app/record/editor/editor.component.spec.ts
@@ -1,0 +1,37 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RecordModule } from '@rero/ng-core';
+
+import { EditorComponent } from './editor.component';
+
+describe('EditorComponent', () => {
+  let component: EditorComponent;
+  let fixture: ComponentFixture<EditorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RecordModule,
+        HttpClientTestingModule,
+        TranslateModule.forRoot(),
+        RouterTestingModule,
+        BrowserAnimationsModule
+      ],
+      declarations: [ EditorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ng-core-tester/src/app/record/editor/editor.component.ts
+++ b/projects/ng-core-tester/src/app/record/editor/editor.component.ts
@@ -1,0 +1,53 @@
+/*
+ * RERO angular core
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component } from '@angular/core';
+import JSONSchema from './schema.json';
+@Component({
+  selector: 'app-editor',
+  templateUrl: './editor.component.html'
+})
+export class EditorComponent {
+
+  // editor settings
+  editorSettings = {
+    longMode: true,  // editor long mode
+    template: {
+      recordType: undefined,    // the resource considerate as template
+      loadFromTemplate: false,  // enable load from template button
+      saveAsTemplate: false     // allow to save the record as a template
+    }
+  };
+
+  // JSONSchema
+  schema = {};
+
+  // form intial values
+  model = {};
+
+  /** Constructor */
+  constructor() {
+    this.schema = JSONSchema;
+  }
+
+  /** Callback when the model values has changed.
+   * @param value - object the new model values
+   */
+  modelChanged(value: object) {
+    this.model = value;
+  }
+
+}

--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -1,0 +1,396 @@
+{
+  "schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Test editor",
+  "additionalProperties": false,
+  "propertiesOrder": [
+    "oneOf",
+    "optional",
+    "required",
+    "essential",
+    "hidden",
+    "defaultHidden",
+    "enum",
+    "object",
+    "object_of_object",
+    "array",
+    "array_of_array",
+    "array_of_object_of_object"
+  ],
+  "required": [
+    "required"
+  ],
+  "properties": {
+    "oneOf": {
+      "title": "oneOf",
+      "type": "object",
+      "additionnalProperties": "false",
+      "oneOf": [
+        {
+          "title": "Property 1",
+          "propertiesOrder": [
+            "name",
+            "type",
+            "hidden"
+          ],
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "form": {
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            },
+            "hidden": {
+              "title": "Hidden name",
+              "type": "string",
+              "form": {
+                "hide": true
+              },
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
+            },
+            "type": {
+              "title": "Type",
+              "type": "string",
+              "const": "type1",
+              "default": "type1",
+              "readOnly": true,
+              "form": {
+                "templateOptions": {
+                  "cssClass": "col-lg-6"
+                }
+              }
+            }
+          },
+          "form": {
+            "templateOptions": {
+              "cssClass": "row"
+            }
+          }
+        },
+        {
+          "title": "Property 2",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "title": "Name",
+              "type": "string"
+            },
+            "type": {
+              "title": "Type",
+              "type": "string",
+              "const": "type2",
+              "default": "type2",
+              "readOnly": true
+            },
+            "bool": {
+              "title": "boolean",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        }
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "alwaysHidden": {
+      "title": "Always hidden",
+      "description": "Not present in the form, not present in the model.",
+      "type": "string",
+      "default": "default",
+      "minLength": 1
+    },
+    "hidden": {
+      "title": "Hidden",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "hide": true
+      }
+    },
+    "defaultHidden": {
+      "title": "Default hidden",
+      "description": "Hidden field with a default value.",
+      "type": "string",
+      "default": "default value",
+      "minLength": 1,
+      "form": {
+        "hide": true
+      }
+    },
+    "essential": {
+      "title": "Essential",
+      "type": "string",
+      "minLength": 1,
+      "form": {
+        "hide": true,
+        "navigation": {
+          "essential": true
+        }
+      }
+    },
+    "optional": {
+      "title": "Optional",
+      "type": "string",
+      "minLength": 1
+    },
+    "required": {
+      "title": "Required",
+      "type": "string",
+      "minLength": 3,
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title editor-max-width"
+        }
+      }
+    },
+    "enum": {
+      "title": "List of values",
+      "type": "string",
+      "default": "val1",
+      "enum": [
+        "val1",
+        "val2",
+        "val3"
+      ],
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title editor-max-width"
+        },
+        "options": [
+          {
+            "value": "Value 1",
+            "label": "val1"
+          },
+          {
+            "value": "Value 2",
+            "label": "val2"
+          },
+          {
+            "value": "Value 3",
+            "label": "val3"
+          }
+        ]
+      }
+    },
+    "object": {
+      "title": "Object",
+      "type": "object",
+      "additionalProperties": false,
+      "propertiesOrder": [
+        "prop1",
+        "prop2"
+      ],
+      "required": [
+        "prop1"
+      ],
+      "properties": {
+        "prop1": {
+          "title": "Property 1",
+          "type": "string"
+        },
+        "prop2": {
+          "title": "Property 2",
+          "type": "string"
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "object_of_object": {
+      "title": "Object of object",
+      "type": "object",
+      "additionalProperties": false,
+      "propertiesOrder": [
+        "object1",
+        "prop3"
+      ],
+      "properties": {
+        "object1": {
+          "title": "Object 1",
+          "type": "object",
+          "additionalProperties": false,
+          "propertiesOrder": [
+            "prop1",
+            "prop2"
+          ],
+          "required": [
+            "prop1"
+          ],
+          "properties": {
+            "prop1": {
+              "title": "Property 1",
+              "type": "string"
+            },
+            "prop2": {
+              "title": "Property 2",
+              "type": "string"
+            }
+          }
+        },
+        "prop3": {
+          "title": "Property 3",
+          "type": "string"
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "array": {
+      "title": "Array",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Properties",
+        "type": "object",
+        "additionalProperties": false,
+        "propertiesOrder": [
+          "prop1",
+          "prop2"
+        ],
+        "required": [
+          "prop1"
+        ],
+        "properties": {
+          "prop1": {
+            "title": "Property 1",
+            "type": "string",
+            "form": {
+              "templateOptions": {
+                "cssClass": "col"
+              }
+            }
+          },
+          "prop2": {
+            "title": "Property 2",
+            "type": "string",
+            "form": {
+              "hide": true,
+              "templateOptions": {
+                "cssClass": "col-lg-6"
+              }
+            }
+          }
+        },
+        "form": {
+          "templateOptions": {
+            "cssClass": "row"
+          }
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    },
+    "array_of_array": {
+      "title": "Array of array",
+      "default": [
+        [
+          "value 1",
+          "value 2"
+        ],
+        [
+          "value 3"
+        ]
+      ],
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Array",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "title": "Values",
+          "type": "string",
+          "minLength": 1
+        },
+        "form": {
+          "templateOptions": {
+            "cssClass": "row"
+          }
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        },
+        "navigation": {
+          "essential": true
+        }
+      }
+    },
+    "array_of_object_of_object": {
+      "title": "Array of object of object",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Object of object",
+        "type": "object",
+        "additionalProperties": false,
+        "propertiesOrder": [
+          "object1",
+          "prop3"
+        ],
+        "properties": {
+          "object1": {
+            "title": "Object1",
+            "type": "object",
+            "additionalProperties": false,
+            "propertiesOrder": [
+              "prop1",
+              "prop2"
+            ],
+            "required": [
+              "prop1"
+            ],
+            "properties": {
+              "prop1": {
+                "title": "Property 1",
+                "type": "string"
+              },
+              "prop2": {
+                "title": "Property 2",
+                "type": "string"
+              }
+            }
+          },
+          "prop3": {
+            "title": "Property 3",
+            "type": "string"
+          }
+        },
+        "form": {
+          "templateOptions": {
+            "cssClass": "row"
+          }
+        }
+      },
+      "form": {
+        "templateOptions": {
+          "cssClass": "editor-title"
+        }
+      }
+    }
+  }
+}

--- a/projects/ng-core-tester/src/app/service/app-menu.service.ts
+++ b/projects/ng-core-tester/src/app/service/app-menu.service.ts
@@ -90,5 +90,8 @@ export class AppMenuService {
       .setRouterLink(['/records', 'documents']);
     menu.addChild('Organisation records')
       .setRouterLink(['/records', 'organisations']);
+    menu.addChild('Editor')
+      .setRouterLink(['/editor'])
+      .setExtra('iconClass', 'fa fa-edit');
   }
 }

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -176,4 +176,4 @@ import { RecordSearchResultDirective } from './search/result/record-search-resul
     { provide: FORMLY_CONFIG, multi: true, useFactory: registerTranslateExtension, deps: [TranslateService] },
   ]
 })
-export class RecordModule {}
+export class RecordModule { }


### PR DESCRIPTION
* Adds a new link in the application demo to show the editor with a
  specific JSONSchema to demonstrate all the possibilities of the editor.
* Makes JSONSchema and editorSettings as Input for the editor component.
* Cleans the empty values in the emitted model.
* Set the defauls model and JSONSchema values if the URL do not contains
  the record type.
* Closes #115.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- To diagnose easily the editor.

## How to test?

- Start the demo application and go to the record menu and click on the editor entry.

__Note__: the editor component file has been re-indented. Sorry for the review.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
