### PR TITLE
security: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14161,8 +14161,7 @@
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "ts-node": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "npm-registry-fetch": ">=4.0.5",
     "rxjs": "^6.5.4",
     "serialize-javascript": ">=3.1.0",
+    "tree-kill": ">=1.2.2",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"
   },


### PR DESCRIPTION
* Upgrades `tree-kill` library to version equal or greater than 1.2.2 to avoid a security issue.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>