### PR TITLE
views: add button to use a resource

### DIFF
--- a/projects/rero/ng-core/src/lib/record/action-status.ts
+++ b/projects/rero/ng-core/src/lib/record/action-status.ts
@@ -21,4 +21,5 @@
 export interface ActionStatus {
     can: boolean;
     message: string;
+    url?: string;
 }

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.html
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.html
@@ -17,8 +17,28 @@
 <div class="main-content">
   <ng-core-error [error]="error" *ngIf="error"></ng-core-error>
   <div class="float-right ml-4 mt-2 mb-4" *ngIf="record && adminMode.can">
-    <a href class="btn btn-sm btn-primary" [routerLink]="['../../edit', record.metadata.pid]"
-      *ngIf="updateStatus && updateStatus.can" id="detail-edit-button">
+    <button *ngIf="useStatus && useStatus.can && useStatus.url"
+            id="detail-use-button"
+            class="btn btn-sm btn-primary ml-1"
+            [ngClass]="{
+               'btn-outline-primary': !isPrimaryAction('use'),
+               'btn-primary': isPrimaryAction('use')
+            }"
+            (click)="useRecord()"
+    >
+      <i class="fa fa-hand-o-right"></i>
+      {{ 'Use' | translate }}
+    </button>
+    <a *ngIf="updateStatus && updateStatus.can"
+       id="detail-edit-button"
+       href
+       class="btn btn-sm ml-1"
+       [ngClass]="{
+           'btn-outline-primary': !isPrimaryAction('edit'),
+           'btn-primary': isPrimaryAction('edit')
+       }"
+       [routerLink]="['../../edit', record.metadata.pid]"
+      >
       <i class="fa fa-pencil"></i>
       {{ 'Edit' | translate }}
     </a>

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
@@ -50,6 +50,15 @@ export class DetailComponent implements OnInit, OnDestroy {
   };
 
   /**
+   * Record can be used ?
+   */
+  useStatus: ActionStatus = {
+    can: false,
+    message: '',
+    url: ''
+  };
+
+  /**
    * Observable resolving record data
    */
   record$: Observable<any> = null;
@@ -161,6 +170,10 @@ export class DetailComponent implements OnInit, OnDestroy {
             this.updateStatus = result;
           });
 
+          this._recordUiService.canUseRecord$(this.record, this._type).subscribe(result => {
+            this.useStatus = result;
+          });
+
           if (this._route.snapshot.data.adminMode) {
             this._route.snapshot.data.adminMode().subscribe((am: ActionStatus) => this.adminMode = am);
           }
@@ -210,6 +223,31 @@ export class DetailComponent implements OnInit, OnDestroy {
   goBack() {
     this._location.back();
   }
+
+  /**
+   * Use the record
+   */
+  useRecord() {
+    this._router.navigateByUrl(this.useStatus.url);
+  }
+
+  /**
+   * define if an action is the primary action for the resource
+   * @param actionName - string: the action name to check
+   * @return boolean
+   */
+  isPrimaryAction(actionName: string): boolean {
+    switch (actionName) {
+      case 'edit':
+      case 'update':
+        return this.updateStatus && this.updateStatus.can && (!this.useStatus || !this.useStatus.can);
+      case 'use':
+        return this.useStatus && this.useStatus.can;
+      default:
+        return false;
+    }
+  }
+
 
   /**
    * Delete the record and go back to previous page.

--- a/projects/rero/ng-core/src/lib/record/record-ui.service.ts
+++ b/projects/rero/ng-core/src/lib/record/record-ui.service.ts
@@ -117,96 +117,10 @@ export class RecordUiService {
       throw new Error(`Configuration not found for type "${type}"`);
     }
     const index = this.types.findIndex(item => item.key === type);
-
     if (index === -1) {
       throw new Error(`Configuration not found for type "${type}"`);
     }
-
     return this.types[index];
-  }
-
-  /**
-   * Check if a record can be added
-   * @param type Type of resource
-   * @returns Observable resolving an object containing the result of a permission check.
-   */
-  canAddRecord$(type: string): Observable<ActionStatus> {
-    const config = this.getResourceConfig(type);
-
-    if (config.canAdd) {
-      return config.canAdd().pipe(first());
-    }
-
-    return of({ can: true, message: '' });
-  }
-
-  /**
-   * Check if a record can be updated
-   * @param record - object, record to check
-   * @param type Type of resource
-   * @returns Observable resolving an object containing the result of a permission check.
-   */
-  canUpdateRecord$(record: object, type: string): Observable<ActionStatus> {
-    const config = this.getResourceConfig(type);
-
-    if (config.permissions) {
-      const permissions = config.permissions(record);
-      if ('canUpdate' in permissions) {
-        return permissions.canUpdate;
-      }
-    }
-
-    if (config.canUpdate) {
-      return config.canUpdate(record).pipe(first());
-    }
-
-    return of({ can: true, message: '' });
-  }
-
-  /**
-   * Check if a record can be deleted
-   * @param record - object, record to check
-   * @param type Type of resource
-   * @returns Observable resolving an object containing the result of a permission check.
-   */
-  canDeleteRecord$(record: object, type: string): Observable<ActionStatus> {
-    const config = this.getResourceConfig(type);
-
-    if (config.permissions) {
-      const permissions = config.permissions(record);
-      if ('canDelete' in permissions) {
-        return permissions.canDelete;
-      }
-    }
-
-    if (config.canDelete) {
-      return config.canDelete(record).pipe(first());
-    }
-
-    return of({ can: true, message: '' });
-  }
-
-  /**
-   * Check if a record can be read
-   * @param record - object, record to check
-   * @param type Type of resource
-   * @returns Observable resolving an object containing the result of a permission check.
-   */
-  canReadRecord$(record: object, type: string): Observable<ActionStatus> {
-    const config = this.getResourceConfig(type);
-
-    if (config.permissions) {
-      const permissions = config.permissions(record);
-      if ('canRead' in permissions) {
-        return permissions.canRead;
-      }
-    }
-
-    if (config.canRead) {
-      return config.canRead(record).pipe(first());
-    }
-
-    return of({ can: true, message: '' });
   }
 
   /**
@@ -215,6 +129,7 @@ export class RecordUiService {
    * @param record - object, record to save
    * @param recordType - string, Type of resource
    * @param action - string, http action: create or update
+   * @param route - ActivatedRoute: the current route used
    */
   redirectAfterSave(pid: string, record: any, recordType: string, action: string, route: ActivatedRoute) {
     const config = this.getResourceConfig(recordType);
@@ -234,4 +149,96 @@ export class RecordUiService {
       this._router.navigate(['../detail', pid], {relativeTo: route, replaceUrl: true});
     }
   }
+
+  // ================================================================
+  //    Permissions
+  // ================================================================
+
+  /**
+   * Check if a record can be added
+   * @param type Type of resource
+   * @returns Observable resolving an object containing the result of a permission check.
+   */
+  canAddRecord$(type: string): Observable<ActionStatus> {
+    const config = this.getResourceConfig(type);
+    return (config.canAdd)
+      ? config.canAdd().pipe(first())
+      : of({ can: true, message: '' });
+  }
+
+  /**
+   * Check if a record can be updated
+   * @param record - object, record to check
+   * @param type Type of resource
+   * @returns Observable resolving an object containing the result of a permission check.
+   */
+  canUpdateRecord$(record: object, type: string): Observable<ActionStatus> {
+    const config = this.getResourceConfig(type);
+    if (config.permissions) {
+      const permissions = config.permissions(record);
+      if ('canUpdate' in permissions) {
+        return permissions.canUpdate;
+      }
+    }
+    return (config.canUpdate)
+      ? config.canUpdate(record).pipe(first())
+      : of({ can: true, message: '' });
+  }
+
+  /**
+   * Check if a record can be deleted
+   * @param record - object, record to check
+   * @param type Type of resource
+   * @returns Observable resolving an object containing the result of a permission check.
+   */
+  canDeleteRecord$(record: object, type: string): Observable<ActionStatus> {
+    const config = this.getResourceConfig(type);
+    if (config.permissions) {
+      const permissions = config.permissions(record);
+      if ('canDelete' in permissions) {
+        return permissions.canDelete;
+      }
+    }
+    return (config.canDelete)
+      ? config.canDelete(record).pipe(first())
+      : of({ can: true, message: '' });
+  }
+
+  /**
+   * Check if a record can be read
+   * @param record - object, record to check
+   * @param type Type of resource
+   * @returns Observable resolving an object containing the result of a permission check.
+   */
+  canReadRecord$(record: object, type: string): Observable<ActionStatus> {
+    const config = this.getResourceConfig(type);
+    if (config.permissions) {
+      const permissions = config.permissions(record);
+      if ('canRead' in permissions) {
+        return permissions.canRead;
+      }
+    }
+    return (config.canRead)
+      ? config.canRead(record).pipe(first())
+      : of({ can: true, message: '' });
+  }
+
+  /**
+   * Check if a record can be used (mainly used for templates)
+   * @param record - object, record to check
+   * @param type Type of resource
+   * @returns Observable resolving an object containing the result of a permission check.
+   */
+   canUseRecord$(record: object, type: string): Observable<ActionStatus> {
+    const config = this.getResourceConfig(type);
+    if (config.permissions) {
+      const permissions = config.permissions(record);
+      if ('canUse' in permissions) {
+        return permissions.canUse;
+      }
+    }
+    return (config.canUse)
+        ? config.canUse(record).pipe(first())
+        : of({ can: false, message: '' });
+   }
 }

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -148,6 +148,7 @@
               [itemViewComponent]="getResultItemComponentView()"
               [canUpdate$]="canUpdateRecord$(record)"
               [canDelete$]="canDeleteRecord$(record)"
+              [canUse$]="canUseRecord$(record)"
               [detailUrl$]="resolveDetailUrl$(record)"
               (deletedRecord)="deleteRecord($event)"
             >

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -571,6 +571,15 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   /**
+   * Check if a record can be used
+   * @param record - object, record to check
+   * @return Observable
+   */
+  canUseRecord$(record: object): Observable<ActionStatus> {
+    return this._recordUiService.canUseRecord$(record, this.currentType);
+  }
+
+  /**
    * Filter the aggregations with given configuration function.
    * If no configuration is given, return the original aggregations.
    * @param records - Result records

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
@@ -15,18 +15,45 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <div class="float-right ml-5 mb-2" *ngIf="adminMode.can">
-    <a href id="result-edit-button" class="btn btn-link p-0 ml-2" [title]="'Edit'|translate" routerLink="edit/{{ record.metadata.pid }}"
-        *ngIf="updateStatus && updateStatus.can">
+    <!-- use button -->
+    <button *ngIf="useStatus && useStatus.can && useStatus.url"
+            id="result-use-button"
+            class="btn btn-sm btn-outline-primary"
+            [title]="'Use' | translate"
+            [name]="'Use' | translate"
+            (click)="useRecord()"
+    >
+        <i class="fa fa-hand-o-right"></i>
+    </button>
+
+    <!-- edit button -->
+    <button *ngIf="updateStatus && updateStatus.can"
+            id="result-edit-button"
+            class="btn btn-sm btn-outline-primary ml-2"
+            [title]="'Edit' | translate"
+            [name]="'Edit' | translate"
+            (click)="editRecord(record.metadata.pid)"
+            routerLink="edit/{{ record.metadata.pid }}">
         <i class="fa fa-pencil"></i>
-    </a>
+    </button>
+
+    <!-- delete button -->
     <span class="ml-2" *ngIf="deleteStatus">
-        <button id="result-delete-button" class="btn btn-link p-0" [title]="'Delete'|translate" (click)="deleteRecord(record.metadata.pid)"
-            *ngIf="deleteStatus.can; else deleteMessageLink">
+        <button *ngIf="deleteStatus.can; else deleteMessageLink"
+                id="result-delete-button"
+                class="btn btn-sm btn-outline-danger"
+                [title]="'Delete' | translate"
+                [name]="'Delete' | translate"
+                (click)="deleteRecord(record.metadata.pid)">
             <i class="fa fa-trash"></i>
         </button>
         <ng-template #deleteMessageLink>
-            <button id="result-delete-button" class="btn btn-link p-0 text-muted" [title]="'Delete'|translate"
-                (click)="showDeleteMessage(deleteStatus.message)" *ngIf="deleteStatus.message">
+            <button id="result-delete-button"
+                    disabled
+                    class="btn btn-sm btn-outline-danger"
+                    [title]="'Delete'|translate"
+                    [name]="'Delete'|translate"
+                    (click)="showDeleteMessage(deleteStatus.message)" *ngIf="deleteStatus.message">
                 <i class="fa fa-trash"></i>
             </button>
         </ng-template>

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.ts
@@ -21,6 +21,8 @@ import { RecordUiService } from '../../record-ui.service';
 import { JsonComponent } from './item/json.component';
 import { ResultItem } from './item/result-item';
 import { RecordSearchResultDirective } from './record-search-result.directive';
+import { Router} from '@angular/router';
+
 
 @Component({
   selector: 'ng-core-record-search-result',
@@ -41,6 +43,11 @@ export class RecordSearchResultComponent implements OnInit {
    * Store if record can be updated or not
    */
   updateStatus: ActionStatus;
+
+  /**
+   * Store if record can be use or not
+   */
+  useStatus: ActionStatus;
 
   /**
    * Detail URL value, resolved by observable property detailUrl$.
@@ -87,6 +94,12 @@ export class RecordSearchResultComponent implements OnInit {
   canDelete$: Observable<ActionStatus>;
 
   /**
+   * Record can be used (mainly for templates)
+   */
+  @Input()
+  canUse$: Observable<ActionStatus>;
+
+  /**
    * Aggregations
    */
   @Input()
@@ -113,10 +126,12 @@ export class RecordSearchResultComponent implements OnInit {
    *
    * @param _componentFactoryResolver Component factory resolver.
    * @param _recordUiService Record UI service.
+   * @param _router: Router
    */
   constructor(
     private _componentFactoryResolver: ComponentFactoryResolver,
-    private _recordUiService: RecordUiService
+    private _recordUiService: RecordUiService,
+    private _router: Router
   ) {
     this.currentUrl = window.location.href;
   }
@@ -134,6 +149,12 @@ export class RecordSearchResultComponent implements OnInit {
     if (this.canUpdate$) {
       this.canUpdate$.subscribe((result: ActionStatus) => {
         this.updateStatus = result;
+      });
+    }
+
+    if (this.canUse$) {
+      this.canUse$.subscribe((result: ActionStatus) => {
+        this.useStatus = result;
       });
     }
 
@@ -163,7 +184,6 @@ export class RecordSearchResultComponent implements OnInit {
 
   /**
    * Delete a record
-   * @param event - Event, dom event fired
    * @param pid - string, pid to delete
    */
   deleteRecord(pid: string) {
@@ -171,8 +191,22 @@ export class RecordSearchResultComponent implements OnInit {
   }
 
   /**
+   * Edit a record
+   * @param pid - string: the pid to edit
+   */
+  editRecord(pid: string) {
+    this._router.navigate(['/', 'records', this.type, 'edit', pid]);
+  }
+
+  /**
+   * Use a record
+   */
+  useRecord() {
+    this._router.navigateByUrl(this.useStatus.url);
+  }
+
+  /**
    * Show dialog with the reason why record cannot be deleted.
-   * @param event - Event
    * @param message - string, message to display
    */
   showDeleteMessage(message: string) {


### PR DESCRIPTION
This commit add the possibility to use a resource. If a resource can be
used, it is associated to an URL to use this resource. This commit also
add a button ('use') for each search result and in the detail view. This
button can be controlled by the 'canUse' parameter from the resource
configuration.

Note :
  * 'editing a resource' is the fact to open the editor for this resource
and update the data.
  * 'using a resource' if the fact to use the resource as a template
skeleton to create an other resource (not necessarily the same resource
type).

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
