### PR TITLE
tester: add proxies for API calls

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -110,6 +110,12 @@
             "browserTarget": "ng-core-tester:build"
           },
           "configurations": {
+            "localhost": {
+              "proxyConfig": "proxies/localhost.json"
+            },
+            "mocklab": {
+              "proxyConfig": "proxies/mocklab.json"
+            },
             "production": {
               "browserTarget": "ng-core-tester:build:production"
             }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.9.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "serve": "ng serve --configuration mocklab",
     "build-lib": "ng build @rero/ng-core",
     "pack": "ng build @rero/ng-core; npm pack dist/rero/ng-core",
     "test-lib": "ng test @rero/ng-core",

--- a/projects/ng-core-tester/src/environments/environment.prod.ts
+++ b/projects/ng-core-tester/src/environments/environment.prod.ts
@@ -17,7 +17,7 @@
 export const environment = {
   production: true,
   prefixWindow: 'NG CORE TESTER',
-  apiBaseUrl: 'https://l985g.mocklab.io',
+  apiBaseUrl: '',
   $refPrefix: 'https://sonar.ch',
   languages: ['fr', 'de', 'it', 'en'],
   translationsURLs: [

--- a/projects/ng-core-tester/src/environments/environment.ts
+++ b/projects/ng-core-tester/src/environments/environment.ts
@@ -22,7 +22,7 @@
 export const environment = {
   production: false,
   prefixWindow: 'NG CORE TESTER',
-  apiBaseUrl: 'https://l985g.mocklab.io',
+  apiBaseUrl: '',
   $refPrefix: 'https://sonar.ch',
   languages: ['fr', 'de', 'it', 'en'],
   translationsURLs: [

--- a/proxies/localhost.json
+++ b/proxies/localhost.json
@@ -1,0 +1,20 @@
+{
+  "/api/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api": "https://localhost:5000/api"
+    }
+  },
+  "/schemas/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/schemas": "https://localhost:5000/schemas"
+    }
+  }
+}

--- a/proxies/mocklab.json
+++ b/proxies/mocklab.json
@@ -1,0 +1,20 @@
+{
+  "/api/*": {
+    "target": "https://l985g.mocklab.io",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api": "https://l985g.mocklab.io/api"
+    }
+  },
+  "/schemas/*": {
+    "target": "https://l985g.mocklab.io",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/schemas": "https://l985g.mocklab.io/schemas"
+    }
+  }
+}


### PR DESCRIPTION
* Adds configurations for `localhost` and `mocklab` api in angular.json
* Adds a `serve` command in package.json to run `ng serve` with the `mocklab` configuration by default.
* Empties environment `apiBaseUrl` variable.
* Creates files for proxying to localhost and mocklab.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>