### PR TITLE
records: edit metadata of files

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -136,6 +136,23 @@ const aggregations = (agg: object) => {
 };
 
 /**
+ * Filter files list (callback function called in Array.prototype.filter)
+ */
+const filterFilesList = (file: any): boolean => {
+  return file.key.indexOf('.pdf') !== -1;
+};
+
+const orderFilesList = (a: any, b: any) => {
+  if (a.metadata.order < b.metadata.order) {
+    return -1;
+  }
+  if (a.metadata.order > b.metadata.order) {
+    return 1;
+  }
+  return 0;
+};
+
+/**
  * Returned matched URL.
  *
  * @param url List of URL segments.
@@ -257,7 +274,12 @@ const routes: Routes = [
           itemHeaders: {
             'Content-Type': 'application/rero+json'
           },
-          filesEnabled: true,
+          files: {
+            enabled: true,
+            filterList: filterFilesList,
+            orderList: orderFilesList,
+            infoExcludedFields: ['restriction', 'type']
+          },
           searchFields: [
             {
               label: 'Full-text',

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
@@ -201,7 +201,7 @@ export class DetailComponent implements OnInit, OnDestroy {
    * @returns True if file management is enabled.
    */
   get filesEnabled(): boolean {
-    return this._config.filesEnabled ? this._config.filesEnabled : false;
+    return this._config.files && this._config.files.enabled ? this._config.files.enabled : false;
   }
 
   /**

--- a/projects/rero/ng-core/src/lib/record/files/files.component.html
+++ b/projects/rero/ng-core/src/lib/record/files/files.component.html
@@ -23,7 +23,7 @@
       <ng-container *ngFor="let file of files">
         <li class="list-group-item" *ngIf="showItem(file)">
           <div class="row">
-            <div class="col-sm-8" [ngClass]="{ 'pl-5 text-muted': !file.is_head }">
+            <div class="col-sm-6" [ngClass]="{ 'pl-5 text-muted': !file.is_head }">
               <p class="m-0">
                 {{ file.key }}
                 <a href="#" class="ml-2" (click)="$event.preventDefault(); file.showInfo = !file.showInfo">
@@ -34,23 +34,14 @@
                   <i class="fa fa-history"></i>
                 </a>
               </p>
-              <dl class="row mt-2 mb-0" *ngIf="file.showInfo">
-                <dt class="col-sm-3" translate>Size</dt>
-                <dd class="col-sm-9">{{ file.size | filesize }}</dd>
-
-                <dt class="col-sm-3" translate>Mime type</dt>
-                <dd class="col-sm-9">{{ file.mimetype }}</dd>
-
-                <dt class="col-sm-3" translate>Checksum</dt>
-                <dd class="col-sm-9">{{ file.checksum }}</dd>
-
-                <dt class="col-sm-3" translate>Modified at</dt>
-                <dd class="col-sm-9">{{ file.updated | dateTranslate:'medium' }}</dd>
-              </dl>
             </div>
-            <div class="col-sm-4 text-right">
-              <button class="btn btn-sm btn-outline-primary" (click)="manageFile(file)">
+            <div class="col-sm-6 text-right">
+              <button class="btn btn-sm btn-outline-primary" (click)="editMetadata(file)"
+                *ngIf="file.is_head && file.metadata">
                 <i class="fa fa-pencil mr-1"></i>{{ 'Edit' | translate }}
+              </button>
+              <button class="btn btn-sm btn-outline-primary ml-1" (click)="manageFile(file)" *ngIf="file.is_head">
+                <i class="fa fa-upload mr-1"></i>{{ 'New version' | translate }}
               </button>
               <a [href]="getFileUrl(file)" target="_blank" class="btn btn-sm btn-outline-primary ml-1" download>
                 <i class="fa fa-download mr-1"></i>{{ 'Download' | translate }}
@@ -58,6 +49,33 @@
               <button class="btn btn-sm btn-outline-danger ml-1" (click)="delete(file)">
                 <i class="fa fa-trash mr-1"></i>{{ 'Delete' | translate }}
               </button>
+            </div>
+          </div>
+          <div class="row mt-2" *ngIf="file.showInfo">
+            <div class="col-lg-6" *ngIf="file.is_head">
+              <dl class="row mt-2 mb-0">
+                <ng-container *ngFor="let item of file.metadata | keyvalue">
+                  <ng-container *ngIf="!infoExcludedFields.includes(item.key) && item.value">
+                    <dt class="col-sm-4">{{ item.key | translate }}</dt>
+                    <dd class="col-sm-8">{{ item.value }}</dd>
+                  </ng-container>
+                </ng-container>
+              </dl>
+            </div>
+            <div class="col-lg-6"[ngClass]="{ 'pl-5 text-muted': !file.is_head }">
+              <dl class="row mt-2 mb-0">
+                <dt class="col-sm-4" translate>Size</dt>
+                <dd class="col-sm-8">{{ file.size | filesize }}</dd>
+
+                <dt class="col-sm-4" translate>Mime type</dt>
+                <dd class="col-sm-8">{{ file.mimetype }}</dd>
+
+                <dt class="col-sm-4" translate>Checksum</dt>
+                <dd class="col-sm-8">{{ file.checksum }}</dd>
+
+                <dt class="col-sm-4" translate>Modified at</dt>
+                <dd class="col-sm-8">{{ file.updated | dateTranslate:'medium' }}</dd>
+              </dl>
             </div>
           </div>
         </li>
@@ -103,5 +121,25 @@
         </button>
       </ng-container>
     </div>
+  </div>
+</ng-template>
+
+<ng-template #metadataFormModal>
+  <div class="modal-header">
+    <h4 class="modal-title pull-left">{{ metadataForm.model.key }}</h4>
+    <button type="button" class="close pull-right" aria-label="Close" (click)="formModalRef.hide()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <form [formGroup]="metadataForm.form" (ngSubmit)="saveMetadata()">
+      <formly-form [form]="metadataForm.form" [model]="metadataForm.model" [fields]="metadataForm.fields"></formly-form>
+      <div class="text-center">
+        <button type="submit" class="btn btn-primary btn-block">
+          <i class="fa fa-floppy-o mr-2"></i>
+          {{ 'Save' | translate }}
+        </button>
+      </div>
+    </form>
   </div>
 </ng-template>

--- a/projects/rero/ng-core/src/lib/record/files/files.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/files/files.component.spec.ts
@@ -16,11 +16,13 @@
  */
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import {
   TranslateFakeLoader,
   TranslateLoader,
   TranslateModule
 } from '@ngx-translate/core';
+import { RecordUiService } from '../record-ui.service';
 import { RecordModule } from '../record.module';
 import { RecordFilesComponent } from './files.component';
 
@@ -28,21 +30,29 @@ describe('RecordFilesComponent', () => {
   let component: RecordFilesComponent;
   let fixture: ComponentFixture<RecordFilesComponent>;
 
+  const recordUiServiceSpy = jasmine.createSpyObj('RecordUiService', [
+    'getResourceConfig',
+  ]);
+  recordUiServiceSpy.getResourceConfig.and.returnValue({ key: 'documents', files: { enabled: true } });
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         RecordModule,
         HttpClientTestingModule,
+        RouterTestingModule,
         TranslateModule.forRoot({
           loader: { provide: TranslateLoader, useClass: TranslateFakeLoader },
         }),
       ],
+      providers: [{ provide: RecordUiService, useValue: recordUiServiceSpy }],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RecordFilesComponent);
     component = fixture.componentInstance;
+    component.type = 'documents';
     fixture.detectChanges();
   });
 

--- a/projects/rero/ng-core/src/lib/record/record.ts
+++ b/projects/rero/ng-core/src/lib/record/record.ts
@@ -42,6 +42,7 @@ export interface File {
   key: string;
   showInfo: boolean;
   showChildren: boolean;
+  metadata: any;
 }
 
 /**


### PR DESCRIPTION
This PR gives the possibility to edit metadata of files. These metadata are stored in record and thus can be different for each type of record.

* Configures a filter function in ng-core-tester to show an example how to filter files.
* Adds `metadata` property in `File` interface.
* Changes the way to activate files management. Now there's an object in configuration instead of `filesEnabled` property.
* Adds a configuration to avoid some fields to be displayed in file's information.
* Adds a configuration to order files.
* Adds a modal to edit file's metadata.
* Shows the metadata of the file in information container.
* Loads whole record to receive the metadata of each files.
* Loads JSON schema corresponding to record type, to initialize the editor.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>
