### PR TITLE
records: validate data during editor submission

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -42,7 +42,7 @@
     <form
       class="col"
       [formGroup]="form"
-      (ngSubmit)="submit($event)"
+      (ngSubmit)="submit()"
     >
       <!-- ngx-formly -->
       <formly-form
@@ -68,7 +68,6 @@
           id="editor-save-button"
           type="submit"
           class="btn btn-primary btn-sm"
-          [disabled]="!form.valid"
         >
           <i class="fa fa-save"></i>
           {{ 'Save' | translate }}

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -397,9 +397,17 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
 
   /**
    * Save the data on the server.
-   * @param event - object, JSON to POST on the backend
    */
-  submit(event) {
+  submit() {
+    this.form.updateValueAndValidity();
+
+    if (this.form.valid === false) {
+      this._toastrService.error(
+        this._translateService.instant('The form contains errors.')
+      );
+      return;
+    }
+
     this._spinner.show();
     this.loadingChange.emit(true);
 


### PR DESCRIPTION
With this PR, the submit button of the editor is always active and validation is done when it is clicked. If validation fails, a toast message is displayed.

* Validates form before saving data.
* Removes unused `event` parameter in `submit` method.
* Makes submit button always active in template.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>