### PR TITLE
aggregations: display simple filter

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
@@ -14,29 +14,38 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<div class="card mb-2"
-  *ngIf="(aggregation.value.buckets && aggregation.value.buckets.length) || aggregation.type !== 'terms'">
-  <div class="card-header p-0">
-    <h5 class="mb-0">
-      <button class="btn btn-link" type="button" (click)="expand = !expand;">
-        {{ aggregation.key | translate | ucfirst }}
-      </button>
-    </h5>
-  </div>
-  <div class="collapse" [class.show]="showAggregation()">
-    <div class="card-body">
-      <ng-container [ngSwitch]="aggregation.type">
-        <!-- Range -->
-        <ng-core-aggregation-slider [key]="aggregation.key" [min]="aggregation.config.min || 1"
-          [max]="aggregation.config.max || 100" [step]="aggregation.config.step || 1"
-          [buckets]="aggregation.value.buckets" *ngSwitchCase="'range'">
-        </ng-core-aggregation-slider>
+<!-- Aggregation with no bucket, containing only the count. -->
+<div class="mb-3" *ngIf="aggregation.doc_count && aggregation.doc_count > 0; else cardAggregation">
+  <ng-core-record-search-aggregation-buckets
+    [buckets]="[{key: '1', doc_count: aggregation.doc_count, name: aggregation.key | translate }]" [aggregationKey]="aggregation.key"
+    [size]="aggregation.bucketSize">
+  </ng-core-record-search-aggregation-buckets>
+</div>
+<ng-template #cardAggregation>
+  <div class="card mb-2"
+    *ngIf="(aggregation.value.buckets && aggregation.value.buckets.length) || aggregation.type !== 'terms'">
+    <div class="card-header p-0">
+      <h5 class="mb-0">
+        <button class="btn btn-link" type="button" (click)="expand = !expand;">
+          {{ aggregation.key | translate | ucfirst }}
+        </button>
+      </h5>
+    </div>
+    <div class="collapse" [class.show]="showAggregation()">
+      <div class="card-body">
+        <ng-container [ngSwitch]="aggregation.type">
+          <!-- Range -->
+          <ng-core-aggregation-slider [key]="aggregation.key" [min]="aggregation.config.min || 1"
+            [max]="aggregation.config.max || 100" [step]="aggregation.config.step || 1"
+            [buckets]="aggregation.value.buckets" *ngSwitchCase="'range'">
+          </ng-core-aggregation-slider>
 
-        <!-- Terms (default) -->
-        <ng-core-record-search-aggregation-buckets [buckets]="aggregation.value.buckets"
-          [aggregationKey]="aggregation.key" [size]="aggregation.bucketSize" *ngSwitchDefault>
-        </ng-core-record-search-aggregation-buckets>
-      </ng-container>
+          <!-- Terms (default) -->
+          <ng-core-record-search-aggregation-buckets [buckets]="aggregation.value.buckets"
+            [aggregationKey]="aggregation.key" [size]="aggregation.bucketSize" *ngSwitchDefault>
+          </ng-core-record-search-aggregation-buckets>
+        </ng-container>
+      </div>
     </div>
   </div>
-</div>
+</ng-template>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
@@ -25,7 +25,7 @@ export class RecordSearchAggregationComponent {
    * Aggregation data
    */
   @Input()
-  aggregation: { key: string, bucketSize: any, value: { buckets: Array<any> }, type: string, config?: any };
+  aggregation: { key: string, bucketSize: any, doc_count?: number, value: { buckets: Array<any> }, type: string, config?: any };
 
   /**
    * Current selected values

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
@@ -286,14 +286,14 @@ describe('RecordSearchComponent', () => {
   it('should reorder aggregations', async(() => {
     component.currentType = 'documents';
     const result = [
-      { key: 'author', bucketSize: null, value: { buckets: [] }, type: 'terms', config: null},
-      { key: 'language', bucketSize: null, value: { buckets: [] }, type: 'terms', config: null},
+      { key: 'author', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
+      { key: 'language', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
     ];
     expect(component.aggregationsOrder(aggregations)).toEqual(result);
 
     const resultOrder = [
-      { key: 'language', bucketSize: null, value: { buckets: [] }, type: 'terms', config: null},
-      { key: 'author', bucketSize: null, value: { buckets: [] }, type: 'terms', config: null},
+      { key: 'language', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
+      { key: 'author', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
     ];
     component['_config'] = { key: 'documents', aggregationsOrder: ['language', 'author'] };
     expect(component.aggregationsOrder(aggregations)).toEqual(resultOrder);

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -519,6 +519,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
           aggregations.push({
             key,
             bucketSize,
+            doc_count: aggr[key].doc_count || null,
             value: { buckets: aggr[key].buckets },
             type: aggr[key].type || 'terms',
             config: aggr[key].config || null
@@ -530,6 +531,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
         aggregations.push({
           key,
           bucketSize,
+          doc_count: aggr[key].doc_count || null,
           value: { buckets: aggr[key].buckets },
           type: aggr[key].type || 'terms',
           config: aggr[key].config || null


### PR DESCRIPTION
This PR allows to display a simple filter that contains only the count for the aggregation. Useful for filtering data based on a single value. For example, it can be used to filter users not associated to an organisation.

* Adds `doc_count` property to aggregation's interface.
* Displays filter as a simple checkbox.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>