### PR TITLE
export: fix urlencode at export

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -492,7 +492,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
    */
   getExportFormatUrl(format: string) {
     const baseUrl = this._apiService.getEndpointByType(this.currentType);
-    let url = `${baseUrl}?q=${this.q}&format=${format}&size=${RecordService.MAX_REST_RESULTS_SIZE}`;
+    let url = `${baseUrl}?q=${encodeURIComponent(this.q)}&format=${format}&size=${RecordService.MAX_REST_RESULTS_SIZE}`;
     if (this.aggregationsFilters) {
       this.aggregationsFilters.map(filter => {
         filter.values.map(v => {


### PR DESCRIPTION
When the user clicks on Export Button, he gets 
an error 400 because url is not encoded.

Co-Authored-by: Benoit Erken <erken.benoit@gmail.com>
Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?
- Test the following URL: /professional/records/items?q=call_number:{"01924" TO "02000"}&page=1&size=10
and click on "Export as CSV". You should receive a file (and not an HTTP 400 Error)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
