### PR TITLE
records: update files metadata

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -90,6 +90,18 @@ const canRead = (record: any): Observable<ActionStatus> => {
   });
 };
 
+/**
+ * Wether files metadata can be updated.
+ *
+ * @param record Record.
+ */
+const canUpdateFilesMetadata = (): Observable<ActionStatus> => {
+  return of({
+    can: true,
+    message: ''
+  });
+};
+
 // Permissions override simple canRead, canUpdate and canDelete if defined
 const permissions = (record: any) => {
   const perms = record.metadata.permissions;
@@ -278,7 +290,8 @@ const routes: Routes = [
             enabled: true,
             filterList: filterFilesList,
             orderList: orderFilesList,
-            infoExcludedFields: ['restriction', 'type']
+            infoExcludedFields: ['restriction', 'type'],
+            canUpdateMetadata: canUpdateFilesMetadata
           },
           searchFields: [
             {

--- a/projects/rero/ng-core/src/lib/record/files/files.component.html
+++ b/projects/rero/ng-core/src/lib/record/files/files.component.html
@@ -37,7 +37,7 @@
             </div>
             <div class="col-sm-6 text-right">
               <button class="btn btn-sm btn-outline-primary" (click)="editMetadata(file)"
-                *ngIf="file.is_head && file.metadata">
+                *ngIf="file.is_head && file.metadata && updateMetadata.can">
                 <i class="fa fa-pencil mr-1"></i>{{ 'Edit' | translate }}
               </button>
               <button class="btn btn-sm btn-outline-primary ml-1" (click)="manageFile(file)" *ngIf="file.is_head">


### PR DESCRIPTION
This commit adds a configuration to determine if metadata of files can be updated for a type of resource.

* Adds a configuration to check if metadata of file can be updated.
* Allows to update metadata for `documents` in tester.
* Checks the new configuration before showing or not the update button.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>