### PR TITLE
editor: fix toggle wrapper if multiple

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/wrappers/toggle-wrapper/toggle-wrappers.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/wrappers/toggle-wrapper/toggle-wrappers.component.ts
@@ -24,8 +24,10 @@ import { isEmpty, removeEmptyValues } from '../../utils';
     <div class='toggle-wrapper'>
       <div class='form-group'>
         <div class="custom-control custom-switch">
-          <input class="custom-control-input" type="checkbox" id="toggle-switch" (change)="toggle($event)" [checked]="tsOptions.enabled">
-          <label class="custom-control-label" for="toggle-switch" [tooltip]="tsOptions.description">{{ tsOptions.label }}</label>
+          <input class="custom-control-input" type="checkbox" id="toggle-switch-{{ field.id }}" \
+                 (change)="toggle($event)" [checked]="tsOptions.enabled">
+          <label class="custom-control-label" for="toggle-switch-{{ field.id }}" \
+                 [tooltip]="tsOptions.description">{{ tsOptions.label }}</label>
         </div>
       </div>
       <ng-container *ngIf="tsOptions.enabled" #fieldComponent></ng-container>


### PR DESCRIPTION
When there are multiple toggle wrappers on the same page, the 'click'
behavior was wrong : whatever switch button clicked, only the first
element was toggle. This commit fixes this problem.

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
