### PR TITLE
editor: fix hide or show empty fields method

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -269,6 +269,9 @@ const routes: Routes = [
           label: 'Documents',
           component: DocumentComponent,
           detailComponent: DetailComponent,
+          editorSettings: {
+            longMode: true
+          },
           canAdd,
           canUpdate,
           canDelete,

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -456,7 +456,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
     let model = field.model;
     // for simple object the model is the parent dict
     if (
-      !['object', 'multischema', 'array'].some(f => f === field.type)
+      field.model != null && !['object', 'multischema', 'array'].some(f => f === field.type)
     ) {
       // New from ngx-formly v5.9.0
       model = field.model[Array.isArray(field.key) ? field.key[0] : field.key];


### PR DESCRIPTION
* Fixes `hideShowEmptyField` method by not setting the model if the current model is not available, for simple fields.
* Activates editor long mode in tester as now it is not activated by default.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>