### PR TITLE
records: add multiple pre filters support

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -499,7 +499,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
    * @return formatted url for an export format.
    */
   getExportFormatUrl(format: string) {
-    const baseUrl = this._apiService.getEndpointByType(this.currentType);
+    const baseUrl = this._apiService.getEndpointByType(this._currentIndex());
     let url = `${baseUrl}?q=${encodeURIComponent(this.q)}&format=${format}&size=${RecordService.MAX_REST_RESULTS_SIZE}`;
     if (this.aggregationsFilters) {
       this.aggregationsFilters.map(filter => {


### PR DESCRIPTION
* Supports multiple values for the pre filters for the API REST call.
  For example `/api/documents/?library=1&library=2`.

Co-authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- https://tree.taiga.io/project/rero21-reroils/us/1544?milestone=275632

## Depends

- https://github.com/rero/rero-ils-ui/pull/425

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
