### PR TITLE
documents: translate files metadata

### DIFF
--- a/projects/rero/ng-core/src/lib/record/files/files.component.html
+++ b/projects/rero/ng-core/src/lib/record/files/files.component.html
@@ -57,7 +57,7 @@
                 <ng-container *ngFor="let item of file.metadata | keyvalue">
                   <ng-container *ngIf="!infoExcludedFields.includes(item.key) && item.value">
                     <dt class="col-sm-4">{{ item.key | translate }}</dt>
-                    <dd class="col-sm-8">{{ item.value }}</dd>
+                    <dd class="col-sm-8">{{ item.value | translate }}</dd>
                   </ng-container>
                 </ng-container>
               </dl>


### PR DESCRIPTION
Adds the `translate` pipe to the files metadata values, to have them translated. This is not useful in most case, but for select options it will be.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>