### PR TITLE
editor: display object label

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.html
@@ -21,27 +21,25 @@
 </div>
 
 <!-- each object properties -->
-<div class="{{ getCssClass() }}">
-  <ng-container *ngFor="let f of field.fieldGroup">
-    <div class="{{ getCssClass(f) }}" *ngIf="!f.hide" [id]="'field-' + f.id">
-      <!-- if the field is repeatable the title is rendered by the corresponding array -->
-      <ng-container *ngIf="((!isParrentArray() && f.type === 'object') || f.type === 'array')">
-        <!-- section header -->
-        <ng-container *ngTemplateOutlet="hasMenu(f) ? menu : title; context: { f: f }">
-        </ng-container>
+<ng-container *ngFor="let f of field.fieldGroup">
+  <div class="{{ getCssClass(f) }}" *ngIf="!f.hide" [id]="'field-' + f.id">
+    <!-- if the field is repeatable the title is rendered by the corresponding array -->
+    <ng-container *ngIf="f.type === 'object' || f.type === 'array'">
+      <!-- section header -->
+      <ng-container *ngTemplateOutlet="hasMenu(f) ? menu : title; context: { f: f }">
       </ng-container>
-      <!-- field -->
-      <div class="d-flex content mb-1">
-        <div class="flex-grow-1">
-          <formly-field [field]="f"></formly-field>
-        </div>
-        <ng-container *ngIf="f.type !== 'array'">
-          <ng-container *ngTemplateOutlet="hideButton; context: { f: f }"></ng-container>
-        </ng-container>
+    </ng-container>
+    <!-- field -->
+    <div class="d-flex content mb-1">
+      <div class="flex-grow-1">
+        <formly-field [field]="f"></formly-field>
       </div>
+      <ng-container *ngIf="f.type !== 'array'">
+        <ng-container *ngTemplateOutlet="hideButton; context: { f: f }"></ng-container>
+      </ng-container>
     </div>
-  </ng-container>
-</div>
+  </div>
+</ng-container>
 
 <!-- TEMPLATES -->
 <!-- dropdown menu -->

--- a/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.ts
@@ -75,14 +75,6 @@ export class ObjectTypeComponent extends FieldType {
   }
 
   /**
-   * Is my parent an array?
-   * @returns boolean, true if my parent is an array
-   */
-  isParrentArray() {
-    return this.field.parent.type === 'array';
-  }
-
-  /**
    * Am I at the root of the form?
    * @returns boolean, true if I'm the root
    */


### PR DESCRIPTION
This PRs displays the label of object fields even if the parent field is not an array.

* Removes CSS class from object container.
* Displays object's label all the time.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## Why are you opening this PR?

To fix theses issues:
![editor](https://user-images.githubusercontent.com/6112685/99365066-14eaf200-28b7-11eb-9e96-8da3ccfa303f.png)
