### PR TITLE
editor: fix cancel button behavior.

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/widgets/load-template-form/load-template-form.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/widgets/load-template-form/load-template-form.component.ts
@@ -108,8 +108,14 @@ export class LoadTemplateFormComponent implements OnInit {
     const formValues = this.form.value;
     this._recordService.getRecord('templates', formValues.template).subscribe(
         (template) => {
-          const params = {...this._route.snapshot.queryParams, ...{source: 'templates', pid: template.metadata.pid}};
-          this._router.navigate([], {queryParams: params});
+          this._router.navigate([], {
+            queryParams: {
+              source: 'templates',
+              pid: template.metadata.pid
+            },
+            queryParamsHandling: 'merge',
+            skipLocationChange: true
+          });
           this.closeModal();
         },
         (error) => {


### PR DESCRIPTION
When we use the editor "cancel" button, the basic behavior navigate to
the previous URL. But, when we use the load template function, this
behavior cause to return to the same form (without templates URL
parameters) and you need to click again on "cancel" button.

This commit fixes this problem by skipping the "loading template URL"
from the browser history.

Closes rero/rero-ils#1453

Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
