### PR TITLE
editor: display a label in typeahead suggestions

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
@@ -50,7 +50,7 @@ export class RemoteTypeaheadService {
       .getRecord(options.type, pid, 1)
       .pipe(
         map(result => {
-          return result.metadata[options.field];
+          return result.metadata[options.label || options.field];
         }),
         map(v => `<strong>${v}</strong>`)
       );
@@ -86,7 +86,7 @@ export class RemoteTypeaheadService {
           }
           results.hits.hits.map((hit: any) => {
             names.push({
-              label: hit.metadata[options.field],
+              label: hit.metadata[options.label || options.field],
               value: this._apiService.getRefEndpoint(options.type, hit.metadata.pid)
               // add a group field to group the results
               // group: 'book'


### PR DESCRIPTION
Displays a label in typeahead suggestions instead of the searched field which may not be present in results fields.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>