### PR TITLE
search: fix missing pre filters behind the export button

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -501,6 +501,18 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
   getExportFormatUrl(format: string) {
     const baseUrl = this._apiService.getEndpointByType(this._currentIndex());
     let url = `${baseUrl}?q=${encodeURIComponent(this.q)}&format=${format}&size=${RecordService.MAX_REST_RESULTS_SIZE}`;
+
+    // preFilters
+    if (this._config && this._config.preFilters) {
+      for (const [key, value] of Object.entries(this._config.preFilters)) {
+        // force value to an array
+        const values = (!Array.isArray(value)) ? [value] : value;
+        values.map(v => {
+          url += `&${key}=${v}`;
+        });
+      }
+    }
+    // aggregations
     if (this.aggregationsFilters) {
       this.aggregationsFilters.map(filter => {
         filter.values.map(v => {


### PR DESCRIPTION
When pre filters is defined on search, they are missing when generating the export URL.

* Adds pre filters into export url.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
