### PR TITLE
editor: fix save alternative problem.

### DIFF
--- a/projects/rero/ng-core/src/lib/core.module.ts
+++ b/projects/rero/ng-core/src/lib/core.module.ts
@@ -42,6 +42,7 @@ import { TranslateLanguagePipe } from './translate/translate-language.pipe';
 import { TranslateLoader } from './translate/translate-loader';
 import { MenuComponent } from './widget/menu/menu.component';
 import { SortListComponent } from './widget/sort-list/sort-list.component';
+import { NgVarDirective } from './directives/ng-var.directive';
 
 @NgModule({
   declarations: [
@@ -61,7 +62,8 @@ import { SortListComponent } from './widget/sort-list/sort-list.component';
     FilesizePipe,
     MenuWidgetComponent,
     SortListComponent,
-    MenuWidgetPrefixSuffixComponent
+    MenuWidgetPrefixSuffixComponent,
+    NgVarDirective
   ],
   imports: [
     CommonModule,
@@ -98,7 +100,8 @@ import { SortListComponent } from './widget/sort-list/sort-list.component';
     SortByKeysPipe,
     NgxSpinnerModule,
     MenuWidgetComponent,
-    SortListComponent
+    SortListComponent,
+    NgVarDirective
   ],
   entryComponents: [DialogComponent]
 })

--- a/projects/rero/ng-core/src/lib/directives/ng-var.directive.ts
+++ b/projects/rero/ng-core/src/lib/directives/ng-var.directive.ts
@@ -1,0 +1,48 @@
+/*
+ * RERO ILS UI
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+
+// tslint:disable-next-line: directive-selector
+@Directive({ selector: '[ngVar]' })
+export class NgVarDirective {
+
+  /** Context */
+  public context: any = {};
+
+  /**
+   * Constructor
+   * @param vcRef - ViewContainerRef
+   * @param templateRef - TemplateRef
+   */
+  constructor(
+      private vcRef: ViewContainerRef,
+      private templateRef: TemplateRef<any>,
+  ) {}
+
+  @Input()
+  set ngVar(context: any) {
+    this.context.$implicit = this.context.ngVar = context;
+    this.updateView();
+  }
+
+  /** Update view */
+  private updateView() {
+    this.vcRef.clear();
+    this.vcRef.createEmbeddedView(this.templateRef, this.context);
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -53,22 +53,26 @@
                         {{ 'Save' | translate }}
                     </button>
                     <ng-container *ngIf="saveAlternatives.length > 0">
-                        <button type="button"
-                                id="editor-save-button-split"
-                                dropdownToggle
-                                class="btn btn-sm btn-primary dropdown-toggle-split"
-                                aria-controls="dropdown-split">
-                            <i class="fa fa-caret-down"></i>
-                        </button>
-                        <ul id="editor-save-button-dropdown-split"
-                            *dropdownMenu
-                            class="dropdown-menu dropdown-menu-right"
-                            role="menu"
-                            aria-labelledby="button-split">
-                            <li role="menuitem" *ngFor="let entry of saveAlternatives">
-                                <a class="dropdown-item" (click)="saveAsTemplate(entry, this)">{{ entry.label }}</a>
-                            </li>
-                        </ul>
+                        <ng-container *ngVar="this as component">
+                            <button type="button"
+                                    id="editor-save-button-split"
+                                    dropdownToggle
+                                    class="btn btn-sm btn-primary dropdown-toggle-split"
+                                    aria-controls="dropdown-split">
+                                <i class="fa fa-caret-down"></i>
+                            </button>
+                            <ul id="editor-save-button-dropdown-split"
+                                *dropdownMenu
+                                class="dropdown-menu dropdown-menu-right"
+                                role="menu"
+                                aria-labelledby="button-split">
+                                <li role="menuitem" *ngFor="let entry of saveAlternatives">
+                                    <a class="dropdown-item" (click)="entry.action(entry, component)">
+                                        {{ entry.label }}
+                                    </a>
+                                </li>
+                            </ul>
+                        </ng-container>
                     </ng-container>
                 </div>
             </div>

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -232,7 +232,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
         if (this.editorSettings.template.saveAsTemplate) {
           this.saveAlternatives.push({
             label: this._translateService.instant('Save as template') + '…',
-            action: this.saveAsTemplate
+            action: this._saveAsTemplate
           });
         }
 
@@ -547,7 +547,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
    *  @param entry: the entry to use to fire this function
    *  @param component: the parent editor component
    */
-  saveAsTemplate(entry, component: EditorComponent) {
+  _saveAsTemplate(entry, component: EditorComponent) {
     // NOTE about `component` param :
     //   As we use `_saveAsTemplate` in a ngFor loop, the common `this` value equals to the current
     //   loop value, not the current component. We need to pass this component as parameter of

--- a/projects/rero/ng-core/src/public-api.ts
+++ b/projects/rero/ng-core/src/public-api.ts
@@ -76,3 +76,4 @@ export * from './lib/utils/sort-by-keys';
 export * from './lib/utils/utils';
 export * from './lib/validator/time.validator';
 export * from './lib/validator/unique.validator';
+export * from './lib/directives/ng-var.directive';


### PR DESCRIPTION
Due the previous changes, the dynamic save alternatives behavior was
broke : all alternatives call the same function instead of to use the
function define for each alternative. This commit fixes this problem.

This commit also introduces the "ngVar" directive to assign value to an
angular variable.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test?

- Try to save a document as a new template. 
- After click on "save as template" alternative, the popup should appear. 
- Enter the template name you want to use and click on 'save' button.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
