### PR TITLE
search: fix result counter

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -349,7 +349,9 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     if (this._config.resultsText) {
       return this._config.resultsText(this.hits);
     }
-    return this._translateService.stream('{{ total }} results', { total: this.total });
+    return (this.total <= 1)
+      ? this._translateService.stream('{{ total }} result', { total: this.total }) // O or 1 result
+      : this._translateService.stream('{{ total }} results', { total: this.total });
   }
 
   /**


### PR DESCRIPTION
When a search result only 1 result, the result counter used always a
plural string. This commit fixes this behavior and get a singular '1
result' string a search return only 1 result.

Closes rero/ng-core#321

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
