### PR TITLE
validators: fix greaterThan validator

### DIFF
--- a/projects/rero/ng-core/src/lib/validator/time.validator.ts
+++ b/projects/rero/ng-core/src/lib/validator/time.validator.ts
@@ -19,12 +19,18 @@ import moment from 'moment';
 
 // @dynamic
 export class TimeValidator {
+
+  /**
+   * Allow to control if time interval limits are well formed : the end limit should be 'older' the start limit
+   * @param start: the field name where to find the start limit value
+   * @param end: the field name where to find the end limit value
+   */
   static greaterThanValidator(start: string, end: string): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } => {
       if (control) {
         let isLessThan = false;
-        const startTime = control.get('start_time');
-        const endTime = control.get('end_time');
+        const startTime = control.get(start);
+        const endTime = control.get(end);
         const startDate = moment(startTime.value, 'HH:mm');
         const endDate = moment(endTime.value, 'HH:mm');
         if (startDate.format('HH:mm') !== '00:00' || endDate.format('HH:mm') !== '00:00') {


### PR DESCRIPTION
The greaterThanValidator requires two arguments to find values to check.
But these arguments were not used. This commit fixes this behavior.

Closes rero/ng-core#320

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
