### PR TITLE
templates: restrict template loading to resource creation.

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -36,7 +36,7 @@
                     {{ 'Cancel' | translate }}
                 </button>
                 <!-- load from template button -->
-                <button *ngIf="editorSettings.template.loadFromTemplate"
+                <button *ngIf="canLoadTemplate()"
                         type="button"
                         id="editor-load-template-button"
                         class="btn btn-outline-primary btn-sm ml-1"

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -637,6 +637,16 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
+  /**
+   * Can the `load template` should be visible.
+   * The 'load template' button will be visible only if the corresponding setting is set and the user
+   * isn't in 'edit mode' (load template is only available for new resources)
+   * @return True if the button could be visible ; False otherwise
+   */
+  canLoadTemplate() {
+    return this.editorSettings.template.loadFromTemplate && !this.pid;
+  }
+
   /********************* Private  ***************************************/
 
   /**


### PR DESCRIPTION
To avoid parent reference problem, the 'load template' button should be
only displayed for resource creation (and hide when a resource is edited).

Closes rero/rero-ils#1471.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
