### PR TITLE
search: remove total count on tab

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -25,7 +25,6 @@
         (click)="changeType($event, type.key)"
       >
         {{ type.label | translate }}
-        <span class="badge badge-light">{{ type.total | default: 0 }}</span>
       </a>
     </li>
   </ul>

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -257,18 +257,6 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
         }
       )
     );
-
-    // Load totals for each resource type
-    if (this.types.length > 1) {
-      for (const type of this.types) {
-        this._recordService.getRecords(
-          type.index ? type.index : type.key, '', 1, 1, [],
-          type.preFilters || {},
-          type.listHeaders || null).subscribe((records: Record) => {
-            type.total = this._recordService.totalHits(records.hits.total);
-          });
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
To make the number of results understandable to the user,
the resource type tab no longer contains the total number of records.

- closes rero/rero-ils#1395

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
