### PR TITLE
editor: fix horizontal wrapper

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -117,7 +117,8 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
     'remoteTypeahead',
     'selectWithSort',
     'integer',
-    'textarea'
+    'textarea',
+    'datepicker'
   ];
 
   // Types to apply field wrapper on

--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -19,7 +19,6 @@ import { FormlyExtension, FormlyFieldConfig } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
 import sha256 from 'crypto-js/sha256';
 import { BehaviorSubject, isObservable } from 'rxjs';
-import { SelectOption } from './interfaces';
 
 /**
  * Add onPopulate hook at the field level.

--- a/projects/rero/ng-core/src/lib/record/editor/wrappers/horizontal-wrapper/horizontal-wrapper.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/wrappers/horizontal-wrapper/horizontal-wrapper.component.ts
@@ -22,8 +22,9 @@ import { FieldWrapper } from '@ngx-formly/core';
   template: `
     <div class="form-group m-0">
       <div class="d-flex">
-        <label [attr.for]="id" class="text-nowrap1 mr-2 col-form-label-1" *ngIf="to.label" [tooltip]="to.description">
-          {{ to.label }}<ng-container *ngIf="to.required && to.hideRequiredMarker !== true">&nbsp;*</ng-container>
+        <label [attr.for]="id" class="text-nowrap mr-2 col-form-label" *ngIf="to.label && to.hideLabel !== true" [tooltip]="to.description" [ngClass]="to.labelClasses">
+          {{ to.label }}
+          <span *ngIf="to.required && to.hideRequiredMarker !== true">*</span>
         </label>
         <div class="flex-grow-1">
           <ng-template #fieldComponent></ng-template>


### PR DESCRIPTION
Adds new possibilities to horizontal field wrapper :
  * parameter to hide the label (true|false).
  * parameter to  customize the label using CSS classes.
Adds the 'datepicker' field type as an horizontal field for long mode
editor.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
