### PR TITLE
bug: correct dropdown menu issue and modal tester config.

### DIFF
--- a/projects/ng-core-tester/src/app/home/home.component.ts
+++ b/projects/ng-core-tester/src/app/home/home.component.ts
@@ -139,7 +139,9 @@ export class HomeComponent implements OnInit {
       initialState: {
         title: 'Confirmation',
         body: 'Exit without saving changes?',
-        confirmButton: true
+        confirmButton: true,
+        cancelTitleButton: 'Abort',
+        confirmTitleButton: 'Confirm'
       }
     };
 

--- a/projects/rero/ng-core/src/lib/dialog/dialog.component.ts
+++ b/projects/rero/ng-core/src/lib/dialog/dialog.component.ts
@@ -36,10 +36,10 @@ export class DialogComponent implements OnInit {
   confirmButton = true;
 
   // Label of cancel button.
-  cancelTitleButton: string;
+  cancelTitleButton = 'Cancel';
 
   // Label of confirmation button.
-  confirmTitleButton: string;
+  confirmTitleButton = 'OK';
 
   // Event triggered when modal is closed.
   onClose: Subject<boolean>;

--- a/projects/rero/ng-core/src/lib/menu/menu-widget/menu-widget.component.html
+++ b/projects/rero/ng-core/src/lib/menu/menu-widget/menu-widget.component.html
@@ -35,7 +35,8 @@
           <li class="nav-item dropdown" dropdown placement="bottom right">
             <a class="nav-link dropdown-toggle"
                dropdownToggle
-               href=""
+               href
+               (click)="false"
                [attr.aria-controls]="item.getAttribute('id')"
             >
               <ng-container [ngTemplateOutlet]="childMenuEntry" [ngTemplateOutletContext]="{item:item}"></ng-container>


### PR DESCRIPTION
In a menu, when a dropdown entry was clicked, the page was reloaded. It
caused by an empty `href` tag. Using an empty `routerLink` binding
property fix this problem.

In the app tester, the button configuration for the modal actions was
missing. Additionally, add default values for modal button if
configuration doesn't provide any values.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
