### PR TITLE
resources: add a config for resource context

### DIFF
--- a/projects/ng-core-tester/src/app/search-bar/search-bar.component.ts
+++ b/projects/ng-core-tester/src/app/search-bar/search-bar.component.ts
@@ -104,7 +104,7 @@ export class SearchBarComponent implements OnInit {
         query: '',
         index: 'organisations',
         category: this._translateService.instant('direct links'),
-        href: `/records/organisations/detail/${hit.metadata.pid}`,
+        href: `/records/organisations/detail/${hit.id}`,
         iconCssClass: 'fa fa-bank'
       });
     });
@@ -136,7 +136,7 @@ export class SearchBarComponent implements OnInit {
         query: hit.metadata.title.replace(/[:\-\[\]()/"]/g, ' ').replace(/\s\s+/g, ' '),
         index: 'documents',
         category: this._translateService.instant('documents')
-        // href: `/${this.viewcode}/documents/${hit.metadata.pid}`
+        // href: `/${this.viewcode}/documents/${hit.id}`
       });
     });
     return values;

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.html
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.html
@@ -41,7 +41,7 @@
            'btn-outline-primary': !isPrimaryAction('edit'),
            'btn-primary': isPrimaryAction('edit')
        }"
-       [routerLink]="['../../edit', record.metadata.pid]"
+       [routerLink]="['../../edit', record.id]"
       >
       <i class="fa fa-pencil"></i>
       {{ 'Edit' | translate }}
@@ -61,5 +61,5 @@
     </ng-container>
   </div>
   <ng-template ngCoreRecordDetail></ng-template>
-  <ng-core-record-files [type]="type" [pid]="record.metadata.pid" *ngIf="record && filesEnabled"></ng-core-record-files>
+  <ng-core-record-files [type]="type" [pid]="record.id" *ngIf="record && filesEnabled"></ng-core-record-files>
 </div>

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
@@ -256,7 +256,7 @@ export class DetailComponent implements OnInit, OnDestroy {
    * @param element - string (PID to remove) or object
    */
   deleteRecord(element: any) {
-    const pid = typeof element === 'object' ? element.metadata.pid : element;
+    const pid = typeof element === 'object' ? element.id : element;
     return this._recordUiService.deleteRecord(this._type, pid).subscribe((result: any) => {
       let redirectUrl = '../..';
       const navigateOptions = { relativeTo: this._route };

--- a/projects/rero/ng-core/src/lib/record/detail/view/json.component.ts
+++ b/projects/rero/ng-core/src/lib/record/detail/view/json.component.ts
@@ -24,7 +24,7 @@ import { DetailRecord } from './detail-record';
 @Component({
   template: `
     <ng-container *ngIf="record">
-      <h1>Record of type "{{ type }}" #{{ record.metadata.pid }}</h1>
+      <h1>Record of type "{{ type }}" #{{ record.id }}</h1>
       {{ record|json }}
     </ng-container>
   `

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -22,7 +22,7 @@
         <div class="header py-2 mb-3 col-12 border-bottom">
             <legend *ngIf="rootFomlyConfig">
                 <span [tooltip]="rootFomlyConfig.templateOptions.description">
-                  {{ rootFomlyConfig.templateOptions.label }}
+                  {{ rootFomlyConfig.templateOptions.label || recordType | ucfirst | translate }}
                 </span>
             </legend>
             <!-- buttons -->

--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
@@ -87,7 +87,7 @@ export class RemoteTypeaheadService {
           results.hits.hits.map((hit: any) => {
             names.push({
               label: hit.metadata[options.label || options.field],
-              value: this._apiService.getRefEndpoint(options.type, hit.metadata.pid)
+              value: this._apiService.getRefEndpoint(options.type, hit.id)
               // add a group field to group the results
               // group: 'book'
             });

--- a/projects/rero/ng-core/src/lib/record/editor/widgets/load-template-form/load-template-form.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/widgets/load-template-form/load-template-form.component.ts
@@ -114,7 +114,7 @@ export class LoadTemplateFormComponent implements OnInit {
           this._router.navigate([], {
             queryParams: {
               source: 'templates',
-              pid: template.metadata.pid
+              pid: template.id
             },
             queryParamsHandling: 'merge',
             skipLocationChange: true

--- a/projects/rero/ng-core/src/lib/record/files/files.component.ts
+++ b/projects/rero/ng-core/src/lib/record/files/files.component.ts
@@ -455,7 +455,7 @@ export class RecordFilesComponent implements OnDestroy, OnInit {
 
     // Update record
     this._recordService
-      .update(this.type, this.record)
+      .update(this.type, this.pid, this.record)
       .pipe(
         switchMap(() => {
           return this._getFiles$();

--- a/projects/rero/ng-core/src/lib/record/record.service.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/record.service.spec.ts
@@ -122,7 +122,7 @@ describe('RecordService', () => {
     };
 
     service.getRecord('documents', '1').subscribe(data => {
-      expect(data.metadata.pid).toBe('1');
+      expect(data.id).toBe('1');
     });
 
     const req = httpMock.expectOne(request => {

--- a/projects/rero/ng-core/src/lib/record/record.service.ts
+++ b/projects/rero/ng-core/src/lib/record/record.service.ts
@@ -14,7 +14,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpErrorResponse,
+  HttpHeaders,
+  HttpParams,
+} from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { TranslateService } from '@ngx-translate/core';
@@ -127,7 +132,7 @@ export class RecordService {
     for (const key of Object.keys(preFilters)) {
       const value = preFilters[key];
       if (Array.isArray(value)) {
-        value.map(val => {
+        value.map((val) => {
           httpParams = httpParams.append(key, val);
         });
       } else {
@@ -179,7 +184,7 @@ export class RecordService {
           headers: this._createRequestHeaders(headers),
         }
       )
-      .pipe(catchError(error => this._handleError(error)));
+      .pipe(catchError((error) => this._handleError(error)));
   }
 
   /**
@@ -218,21 +223,18 @@ export class RecordService {
   }
 
   /**
-   * Create a new record
+   * Update a record
    * @param recordType - string, type of resource
-   * @param record - object, record to create
    * @param pid - string, record PID
+   * @param record - object, record to update
    */
-  update(recordType: string, record: { pid: string }) {
-    const url = `${this._apiService.getEndpointByType(recordType, true)}/${
-      record.pid
-      }`;
-    return this._http
-      .put(url, record)
-      .pipe(
-        catchError((error) => this._handleError(error)),
-        tap(() => this.onUpdate.next(this._createEvent(recordType, { record })))
-      );
+  update(recordType: string, pid: string, record: any) {
+    const url = `${this._apiService.getEndpointByType(recordType, true)}/${pid}`;
+
+    return this._http.put(url, record).pipe(
+      catchError((error) => this._handleError(error)),
+      tap(() => this.onUpdate.next(this._createEvent(recordType, { record })))
+    );
   }
 
   /**
@@ -317,7 +319,9 @@ export class RecordService {
     switch (typeof total) {
       case 'object':
         if (relation) {
-          return `${this._translateService.instant(total.relation)} ${total.value.toString()}`;
+          return `${this._translateService.instant(
+            total.relation
+          )} ${total.value.toString()}`;
         }
         return Number(total.value);
       case 'number':

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
@@ -274,13 +274,13 @@ describe('RecordSearchComponent', () => {
     component['currentType'] = 'documents';
     component.detailUrl = '/custom/url/for/detail/:type/:pid';
 
-    component.resolveDetailUrl$({ metadata: { pid: 100 } }).subscribe((result: any) => {
+    component.resolveDetailUrl$({ id: 100 }).subscribe((result: any) => {
       expect(result.link).toBe('/custom/url/for/detail/documents/100');
     });
 
     component.detailUrl = null;
 
-    component.resolveDetailUrl$({ metadata: { pid: 100 } }).subscribe((result: any) => {
+    component.resolveDetailUrl$({ id: 100 }).subscribe((result: any) => {
       expect(result.link).toBe('detail/100');
     });
   }));

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -658,10 +658,10 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
    * @return Observable emitting detail URL object
    */
   resolveDetailUrl$(record: any): Observable<any> {
-    const url = { link: `detail/${record.metadata.pid}`, external: false };
+    const url = { link: `detail/${record.id}`, external: false };
 
     if (this.detailUrl) {
-      url.link = this.detailUrl.replace(':type', this._currentIndex()).replace(':pid', record.metadata.pid);
+      url.link = this.detailUrl.replace(':type', this._currentIndex()).replace(':pid', record.id);
       url.external = true;
     }
 

--- a/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/result/record-search-result.component.html
@@ -32,8 +32,8 @@
             class="btn btn-sm btn-outline-primary ml-2"
             [title]="'Edit' | translate"
             [name]="'Edit' | translate"
-            (click)="editRecord(record.metadata.pid)"
-            routerLink="edit/{{ record.metadata.pid }}">
+            (click)="editRecord(record.id)"
+            routerLink="edit/{{ record.id }}">
         <i class="fa fa-pencil"></i>
     </button>
 
@@ -44,7 +44,7 @@
                 class="btn btn-sm btn-outline-danger"
                 [title]="'Delete' | translate"
                 [name]="'Delete' | translate"
-                (click)="deleteRecord(record.metadata.pid)">
+                (click)="deleteRecord(record.id)">
             <i class="fa fa-trash"></i>
         </button>
         <ng-template #deleteMessageLink>


### PR DESCRIPTION
* Adds a configuration in routing data to set the context for the resource. This is useful for using resources in the context of `invenio-records-resources`.
* Uses `id` property of record instead of `metadata.pid` as this property not exists anymore with `invenio-records-resources`.
* Displays a default title for resource if `templateOptions.label` is not set.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>