### PR TITLE
editor: improve typeahead

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.html
@@ -43,18 +43,18 @@
 </ng-container>
 
 <ng-template #customListTemplate let-matches="matches" let-query="query" let-typeaheadTemplateMethods>
-  <ul class="list-group">
-    <ng-container *ngFor="let match of matches">
-      <li [ngClass]="{'disabled font-weight-bold': match.header}" class="list-group-item list-group-item-action"
-        [class.active]="typeaheadTemplateMethods.isActive(match)">
-        <span (click)="typeaheadTemplateMethods.selectMatch(match, $event)"
-          (mouseenter)="typeaheadTemplateMethods.selectActive(match)">
-          {{match.value}}
-        </span>
-        <a *ngIf="match.item.externalLink && typeaheadTemplateMethods.isActive(match)" target="_blank" href="{{match.item.externalLink}}">
-          <i class="float-right fa fa-external-link text-light"></i>
-        </a>
-      </li>
-    </ng-container>
-  </ul>
+  <ng-container *ngFor="let match of matches">
+    <div [ngClass]="{ 'disabled font-weight-bold': match.header }" class="dropdown-item"
+      [class.active]="typeaheadTemplateMethods.isActive(match)">
+      <span (click)="typeaheadTemplateMethods.selectMatch(match, $event)"
+        (mouseenter)="typeaheadTemplateMethods.selectActive(match)">
+        <span *ngIf="match.item.currentSearch">{{ 'Add' | translate }}:&nbsp;</span>
+        {{ match.value }}
+      </span>
+      <a *ngIf="match.item.externalLink && typeaheadTemplateMethods.isActive(match)" target="_blank"
+        href="{{ match.item.externalLink }}">
+        <i class="float-right fa fa-external-link text-light"></i>
+      </a>
+    </div>
+  </ng-container>
 </ng-template>

--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.ts
@@ -112,14 +112,6 @@ export class RemoteTypeaheadComponent extends FieldType implements OnInit {
   }
 
   /**
-   * Render the string representation of the $ref.
-   * @returns string - html to inject in the template.
-   */
-  getValueAsHTML(): Observable<string> {
-    return this._remoteTypeaheadService.getValueAsHTML(this._rtOptions, this.formControl.value);
-  }
-
-  /**
    * Clear current value
    */
   clear(): void {

--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
@@ -44,6 +44,15 @@ export class RemoteTypeaheadService {
    * @returns Observable of string - html template representation of the value.
    */
   getValueAsHTML(options, value: string): Observable<string> {
+    // If value does not contain a $ref, we juste have to return the value,
+    // no need to search in backend.
+    const $refExpression = new RegExp(
+      `^https?:\/\/.*\/${options.type}\/[^\/]+$`
+    );
+    if ($refExpression.test(value) === false) {
+      return of(`<strong>${value}</strong>`);
+    }
+
     const url = value.split('/');
     const pid = url.pop();
     return this._recordService
@@ -92,6 +101,16 @@ export class RemoteTypeaheadService {
               // group: 'book'
             });
           });
+
+          // If add new option is allowed, the current value is pushed to
+          // the suggestions.
+          if (
+            options.allowAdd === true &&
+            names.some((item) => item.label === query) === false
+          ) {
+            names.push({ label: query, value: query, currentSearch: true });
+          }
+
           return names;
         })
       );


### PR DESCRIPTION
* Makes the typeahead working with simple fields and not only `$ref`.
* Adds the support to create an entry and not select the existing ones.
* Improves the display of suggestions.
* Removes unused method `getValueAsHTML`.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>