### PR TITLE
search: fix search filters

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -38,6 +38,7 @@ export interface SearchParams {
   size: number;
   aggregationsFilters: Array<AggregationsFilter>;
   sort: string;
+  searchFields: Array<SearchField>;
 }
 
 @Component({
@@ -781,7 +782,8 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
       page: this.page,
       size: this.size,
       sort: this.sort,
-      aggregationsFilters: this.aggregationsFilters
+      aggregationsFilters: this.aggregationsFilters,
+      searchFields: this.searchFields
     };
   }
 


### PR DESCRIPTION
* Takes into account the search filters when the check if the parameters have changed is done. Without that, the click on search filters buttons have no effect.
* Closes rero/sonar#510.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>