### PR TITLE
editor: some fields should not submit the form

### DIFF
--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -189,7 +189,12 @@
     "required": {
       "title": "Required",
       "type": "string",
-      "minLength": 3
+      "minLength": 3,
+      "form": {
+        "templateOptions": {
+          "doNotSubmitOnEnter": true
+        }
+      }
     },
     "enum": {
       "title": "List of values",

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -433,7 +433,6 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
             this._setRemoteTypeahead(field, formOptions);
           }
 
-
           if (this._resourceConfig != null && this._resourceConfig.formFieldMap) {
             return this._resourceConfig.formFieldMap(field, jsonSchema);
           }
@@ -776,6 +775,14 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
       field.templateOptions = {
         ...field.templateOptions,
         ...formOptions.templateOptions
+      };
+    }
+    // some fields should not submit the form when enter key is pressed
+    if (field.templateOptions.doNotSubmitOnEnter != null) {
+      field.templateOptions.keydown = (f: FormlyFieldConfig, event?: any) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+        }
       };
     }
   }


### PR DESCRIPTION
* Adds a new `doNotSubmitOnEnter` boolean templateOptions form property
  to avoid form submission when the enter key is pressed.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
