### PR TITLE
aggregation: make the name customizable

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
@@ -32,7 +32,7 @@
             'fa-chevron-down': !expand && aggregationFilters.length == 0,
             'fa-chevron-right': aggregationFilters.length > 0
           }"></i>
-          {{ aggregation.key | translate | ucfirst }}
+          {{ (aggregation.name || aggregation.key) | translate | ucfirst }}
         </button>
       </h5>
     </div>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
@@ -22,7 +22,15 @@ import { Component, Input } from '@angular/core';
 })
 export class RecordSearchAggregationComponent {
   /** Aggregation data */
-  @Input() aggregation: { key: string, bucketSize: any, doc_count?: number, value: { buckets: Array<any> }, type: string, config?: any };
+  @Input() aggregation: {
+    key: string,
+    bucketSize: any,
+    doc_count?: number,
+    value: { buckets: Array<any> },
+    type: string,
+    config?: any,
+    name?: string
+  };
   /** Current selected values */
   @Input() aggregationsFilters = [];
   /** If true, by default buckets are displayed. */

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -90,6 +90,7 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
     preFilters?: any,
     listHeaders?: any,
     itemHeaders?: any,
+    aggregationsName?: any,
     aggregationsOrder?: Array<string>,
     aggregationsExpand?: Array<string>,
     aggregationsBucketSize?: number,

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
@@ -288,14 +288,14 @@ describe('RecordSearchComponent', () => {
   it('should reorder aggregations', waitForAsync(() => {
     component.currentType = 'documents';
     const result = [
-      { key: 'author', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
-      { key: 'language', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
+      { key: 'author', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null, name: null},
+      { key: 'language', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null, name: null},
     ];
     expect(component.aggregationsOrder(aggregations)).toEqual(result);
 
     const resultOrder = [
-      { key: 'language', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
-      { key: 'author', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null},
+      { key: 'language', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null, name: null},
+      { key: 'author', bucketSize: null, doc_count: null, value: { buckets: [] }, type: 'terms', config: null, name: null},
     ];
     component['_config'] = { key: 'documents', aggregationsOrder: ['language', 'author'] };
     expect(component.aggregationsOrder(aggregations)).toEqual(resultOrder);

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -105,6 +105,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     preFilters?: any,
     listHeaders?: any,
     itemHeaders?: any,
+    aggregationsName?: any,
     aggregationsOrder?: Array<string>,
     aggregationsExpand?: Array<string>,
     aggregationsBucketSize?: number,
@@ -585,7 +586,8 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
             doc_count: aggr[key].doc_count || null,
             value: { buckets: aggr[key].buckets },
             type: aggr[key].type || 'terms',
-            config: aggr[key].config || null
+            config: aggr[key].config || null,
+            name: aggr[key].name || this._aggregationName(key)
           });
         }
       });
@@ -597,7 +599,8 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
           doc_count: aggr[key].doc_count || null,
           value: { buckets: aggr[key].buckets },
           type: aggr[key].type || 'terms',
-          config: aggr[key].config || null
+          config: aggr[key].config || null,
+          name: aggr[key].name || this._aggregationName(key)
         });
       });
     }
@@ -840,5 +843,16 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
       return null;
     }
     return this._config.index ? this._config.index : this._config.key;
+  }
+
+  /**
+   * Get personalized name for current aggregation
+   * @param key - string, aggregation key
+   * @return string or null
+   */
+  private _aggregationName(key: string): string | null {
+    return this._config.aggregationsName && key in this._config.aggregationsName
+      ? this._config.aggregationsName[key]
+      : null;
   }
 }


### PR DESCRIPTION
A new parameter "aggregationsName" has been added
to the configuration to allow the customization of the aggregation name.
Supports a name property to set a custom title for an aggregation.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Why are you opening this PR?

- allow the customization of the facet name

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
