### PR TITLE
editor: add support for multiple select

### DIFF
--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -25,7 +25,8 @@
     "hidden_sub_property_hide_expr",
     "array_of_objects_with_sub_objects",
     "select",
-    "selectGroup"
+    "selectGroup",
+    "selectMultiple"
   ],
   "required": [
     "required"
@@ -589,7 +590,11 @@
     "select": {
       "title": "Select with option tree",
       "type": "string",
-      "enum": ["value1", "value2", "value3"],
+      "enum": [
+        "value1",
+        "value2",
+        "value3"
+      ],
       "form": {
         "options": [
           {
@@ -626,13 +631,20 @@
             "value": "value2",
             "preferred": true
           }
-        ]
+        ],
+        "templateOptions": {
+          "minItemsToDisplaySearch": 3
+        }
       }
     },
     "selectGroup": {
       "title": "Select group (compatibility)",
       "type": "string",
-      "enum": ["value1", "value2", "value3"],
+      "enum": [
+        "value1",
+        "value2",
+        "value3"
+      ],
       "form": {
         "options": [
           {
@@ -648,6 +660,40 @@
             "label": "2 Value",
             "value": "value2",
             "group": "test"
+          }
+        ]
+      }
+    },
+    "selectMultiple": {
+      "title": "Multiple select",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "default": [
+        "value2",
+        "value3"
+      ],
+      "items": {
+        "type": "string",
+        "enum": [
+          "value1",
+          "value2",
+          "value3"
+        ]
+      },
+      "form": {
+        "options": [
+          {
+            "label": "Value 1",
+            "value": "value1"
+          },
+          {
+            "label": "Value 2",
+            "value": "value2"
+          },
+          {
+            "label": "Value 3",
+            "value": "value3"
           }
         ]
       }

--- a/projects/rero/ng-core/src/lib/record/editor/type/custom-select/custom-select.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/custom-select/custom-select.component.html
@@ -17,7 +17,8 @@
 <div class="btn-group mt-1" dropdown #dropdown="bs-dropdown" [insideClick]="true" [isDisabled]="to.readonly">
   <button id="button-basic" dropdownToggle type="button"
     class="btn btn-outline-primary btn-sm btn-block dropdown-toggle px-3" aria-controls="dropdown-basic">
-    {{ selectedOption?.translatedLabel || ('Select an option' | translate) }} <span class="caret"></span>
+    {{ selectedOptions.length ? selectedValuesAsString : ('Select an option' | translate) }}
+    <span class="caret"></span>
   </button>
   <div id="dropdown-basic" *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="button-basic">
     <div class="px-4 py-2" *ngIf="filter || filteredOptions.length > to.minItemsToDisplaySearch">
@@ -26,9 +27,8 @@
     </div>
     <ng-container *ngIf="filteredOptions.length; else noResult">
       <ng-container *ngFor="let option of filteredOptions">
-        <a class="dropdown-item"
-          [ngClass]="{ active: selectedOption && selectedOption.value === option.value, disabled: option.disabled }"
-          href="#" (click)="$event.preventDefault(); selectOption(option); dropdown.hide()"
+        <a class="dropdown-item" [ngClass]="{ active: isOptionSelected(option), disabled: option.disabled }" href="#"
+          (click)="$event.preventDefault(); selectOption(option); dropdown.hide()"
           *ngIf="option.value != null; else group">
           {{ !filter ? '&nbsp;&nbsp;&nbsp;&nbsp;'.repeat(option.level) + ' ' : '' }}{{ option.translatedLabel }}
         </a>


### PR DESCRIPTION
* Adds the support for multiple select options in custom select.
* Improves the filtered list by removing duplicate values.
* Refactors the way selected options are set.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>