### PR TITLE
editor: add context for remote typeahead

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.ts
@@ -16,6 +16,7 @@
  */
 
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { FieldType } from '@ngx-formly/core';
 import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { Observable, Observer } from 'rxjs';
@@ -52,10 +53,9 @@ export class RemoteTypeaheadComponent extends FieldType implements OnInit {
   /**
    * Constructor
    * @param _remoteTypeaheadService - RemoteTypeaheadService
+   * @param _route - Activated route
    */
-  constructor(
-    private _remoteTypeaheadService: RemoteTypeaheadService
-  ) {
+  constructor(private _remoteTypeaheadService: RemoteTypeaheadService, private _route: ActivatedRoute) {
     super();
   }
 
@@ -67,7 +67,12 @@ export class RemoteTypeaheadComponent extends FieldType implements OnInit {
       observer.next(this.search);
     }).pipe(
       switchMap((query: string) => {
-        return this._remoteTypeaheadService.getSuggestions(this._rtOptions, query, this._numberOfSuggestions);
+        return this._remoteTypeaheadService.getSuggestions(
+          this._rtOptions,
+          query,
+          this._numberOfSuggestions,
+          this._route.snapshot.params.pid || null
+        );
       })
     );
 

--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.service.ts
@@ -79,12 +79,14 @@ export class RemoteTypeaheadService {
    * @param options - remote typeahead options
    * @param query - search query to retrieve the suggestions list
    * @param numberOfSuggestions - the max number of suggestion to return
+   * @param currentPid - current edited record PID or null in case of add.
    * @returns - an observable of the list of suggestions.
    */
   getSuggestions(
     options: any,
     query: string,
-    numberOfSuggestions: number
+    numberOfSuggestions: number,
+    currentPid: string
   ): Observable<Array<SuggestionMetadata | string>> {
     if (!query) {
       return of([]);
@@ -102,12 +104,18 @@ export class RemoteTypeaheadService {
           })
         );
     } else {
+      const filters: any = {};
+      if (currentPid) {
+        filters.currentPid = currentPid;
+      }
       suggestions$ = this._recordService
         .getRecords(
           options.type,
           `${options.field}:${query}`,
           1,
-          numberOfSuggestions
+          numberOfSuggestions,
+          [],
+          filters
         )
         .pipe(
           map((results: Record) => {


### PR DESCRIPTION
Adds the currently edited record PID to suggestions backend request, to be able to do a specific process with the given PID.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>