### PR TITLE
editor: fix `custom-select` widget display

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/type/custom-select/custom-select.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/custom-select/custom-select.component.html
@@ -1,27 +1,28 @@
 <!--
- RERO angular core
- Copyright (C) 2021 RERO
-
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Affero General Public License as published by
- the Free Software Foundation, version 3 of the License.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ RERO angular core
+ Copyright (C) 2021 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <div>
-  <div class="btn-group mt-1" dropdown #dropdown="bs-dropdown" [insideClick]="true" [isDisabled]="to.readonly">
+  <div class="btn-group my-2 w-100" dropdown #dropdown="bs-dropdown" [insideClick]="true" [isDisabled]="to.readonly">
     <button id="button-basic" dropdownToggle type="button"
-      class="btn btn-outline-primary btn-sm btn-block dropdown-toggle px-3" aria-controls="dropdown-basic">
+            class="btn btn-outline-primary btn-block dropdown-toggle px-3 text-left d-flex align-items-center"
+            aria-controls="dropdown-basic">
       {{ selectedOptions.length ? selectedValuesAsString : ('Select an option' | translate) }}
-      <span class="caret"></span>
+      <span class="caret ml-auto"></span>
     </button>
-    <div id="dropdown-basic" *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="button-basic">
+    <div id="dropdown-basic" *dropdownMenu class="dropdown-menu w-100" role="menu" aria-labelledby="button-basic">
       <div class="px-4 py-2" *ngIf="filter || filteredOptions.length > to.minItemsToDisplaySearch">
         <input type="text" class="form-control form-control-sm" (input)="onFilterChange($event.target.value)"
           [value]="filter" [placeholder]="'Filter...' | translate" />

--- a/projects/rero/ng-core/src/lib/record/editor/type/custom-select/custom-select.component.scss
+++ b/projects/rero/ng-core/src/lib/record/editor/type/custom-select/custom-select.component.scss
@@ -14,23 +14,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-.btn-group > button {
-  color: #495057 !important;
-  font-size: 0.9rem;
-  border: 1px solid #ced4da !important;
-  box-shadow: none !important;
-  background-color: transparent !important;
-}
+.btn-group {
+  & > button {
+    color: #495057 !important;
+    border: 1px solid #ced4da !important;
+    box-shadow: none !important;
+    background-color: transparent !important;
 
-.btn-group > button:hover {
-  background-color: transparent !important;
-}
-
-.btn-group .dropdown-item {
-  font-size: 0.8rem !important;
-}
-
-.btn-group .dropdown-menu {
-  max-height: 300px;
-  overflow: scroll;
+    &:hover {
+      background-color: transparent !important;
+    }
+  }
+  .dropdown-menu {
+    max-height: 300px;
+    overflow: scroll;
+  }
 }


### PR DESCRIPTION
The `custom-select` display (select dropdown) doesn't look like other
input field. Fix the widget to get a very near display.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## How to test

BEFORE

![image](https://user-images.githubusercontent.com/10031585/121487785-bca24b80-c9d2-11eb-85c6-95358612c05a.png)

AFTER 

![image](https://user-images.githubusercontent.com/10031585/121487878-d0e64880-c9d2-11eb-83bd-9a50dd91c2e9.png)

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
