### PR TITLE
editor: add min/max keys validator on object

### DIFF
--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -365,6 +365,10 @@
           "prop1": {
             "title": "Property 1",
             "type": "string",
+            "enum": [
+              "value#1",
+              "value#2"
+            ],
             "minLength": 3,
             "form": {
               "templateOptions": {
@@ -387,6 +391,19 @@
         "form": {
           "templateOptions": {
             "containerCssClass": "row"
+          }
+        }
+      },
+      "form": {
+        "validation": {
+          "validators": {
+            "numberOfSpecificValuesInObject": {
+              "min": 1,
+              "max": 2,
+              "keys": {
+                "prop1": "value#1"
+              }
+            }
           }
         }
       }

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -112,6 +112,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
   private _customValidators = [
     'valueAlreadyExists',
     'uniqueValueKeysInObject',
+    'numberOfSpecificValuesInObject',
     'dateMustBeGreaterThan',
     'dateMustBeLessThan'
   ];


### PR DESCRIPTION
Allow to validate an array of object based on minimum or/and maximum
key/value pairs. Ex: for a document, allow to specify that a document
must have strictly one main title.

Closes rero/rero-ils#1361.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
