### PR TITLE
editor: improve error message

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.ts
@@ -795,12 +795,12 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
 
   /**
    * Handle form error
-   * @param object with status and title parameters
+   * @param error: object with status and title parameters
    * @return Observable<Error>
    */
   private _handleError(error: { status: number, title: string }): Observable<Error> {
     this._spinner.hide();
-    this.form.setErrors({ formError: true });
+    this.form.setErrors({ formError: error });
     return throwError({ status: error.status, title: error.title });
   }
 }

--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -399,7 +399,7 @@ export function registerNgCoreFormlyExtension(
       {
         name: 'formError',
         // use a marker to force translation extraction due to a bad detection of ngx-translate-extract
-        message: () => translate.stream(_('The form contains errors.'))
+        message: (err) => translate.stream(err.title)
       },
       {
         name: 'required',

--- a/projects/rero/ng-core/src/lib/record/record.service.ts
+++ b/projects/rero/ng-core/src/lib/record/record.service.ts
@@ -359,34 +359,26 @@ export class RecordService {
    * @return throwError
    */
   private _handleError(error: HttpErrorResponse): Observable<Error> {
-    let title: string;
-    let status = error.status;
-
-    switch (status) {
-      case 400: {
-        title = this._translateService.instant('Bad request');
-        break;
-      }
-      case 401: {
-        title = this._translateService.instant('Unauthorized');
-        break;
-      }
-      case 403: {
-        title = this._translateService.instant('Forbidden');
-        break;
-      }
-      case 404: {
-        title = this._translateService.instant('Not found');
-        break;
-      }
-      default: {
-        title = this._translateService.instant('An error occurred');
-        status = 500;
-        break;
-      }
+    // check if we have possible custom error message to display
+    if (error.status === 400 && error.error.hasOwnProperty('message')) {
+      let message = error.error.message;
+      message = message.replace(/^Validation error: /, '').trim();  // Remove invenio `ValidationError` header
+      return throwError({ status: error.status, title: this._translateService.instant(message) });
     }
 
-    return throwError({ status, title });
+    // If not, then return default message
+    switch (error.status) {
+      case 400:
+        return throwError({ status: error.status, title: this._translateService.instant('Bad request') });
+      case 401:
+        return throwError({ status: error.status, title: this._translateService.instant('Unauthorized') });
+      case 403:
+        return throwError({ status: error.status, title: this._translateService.instant('Forbidden') });
+      case 404:
+        return throwError({ status: error.status, title: this._translateService.instant('Not found') });
+      default:
+        return throwError({ status: 500, title: this._translateService.instant('An error occurred') });
+    }
   }
 
   /**


### PR DESCRIPTION
Rather than a generic error message, try to use the message returned by
backend when an error is detected on the editor form.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>


## How to test?
![image](https://user-images.githubusercontent.com/10031585/124114122-79387b80-da6c-11eb-9f57-fb3d74681e38.png)



## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
