### PR TITLE
search: fix double enter fire event

### DIFF
--- a/projects/rero/ng-core/src/lib/search-input/search-input.component.html
+++ b/projects/rero/ng-core/src/lib/search-input/search-input.component.html
@@ -18,7 +18,7 @@
 <div class="input-group px-0">
   <input #searchinput type="text" id="search" class="form-control"
     [attr.placeholder]="!displayLabel && placeholder ? placeholder : null" attr.aria-label="{{ placeholder }}"
-    [value]="searchText" (keyup.enter)="doSearch(searchinput.value)">
+    [value]="searchText" (keydown.enter)="doSearch(searchinput.value)">
   <div class="input-group-append">
     <button class="btn btn-outline-primary" type="button" id="button-search" (click)="doSearch(searchinput.value)">
       <span class="fa fa-search" aria-hidden="true"></span>


### PR DESCRIPTION
When using the main search box and validate it using 'enter' key, the
small 'input search box' from document result page was also fired and
cause a double search. The second request removes all filters from URL.

Closes rero/rero-ils#2130.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
