### PR TITLE
api: add `facets` parameter to `getRecords`

### DIFF
--- a/projects/rero/ng-core/src/lib/record/record.service.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/record.service.spec.ts
@@ -113,6 +113,32 @@ describe('RecordService', () => {
     httpMock.verify();
   });
 
+  it('should return requested aggregations', () => {
+    const expectedData: Record = {
+      aggregations: {
+        authors: {
+          buckets: [{
+           doc_count: 2,
+           key: 'Doe, John'
+          }]
+        }
+      },
+      hits: {
+        total: 2
+      },
+      links: {}
+    };
+
+    service
+        .getRecords('documents', '', 1, 10, [{ key: 'author', values: ['John doe'] }], undefined, null, null, ['authors'])
+        .subscribe((data: Record) => {
+          expect(data.aggregations.authors.buckets[0].doc_count).toBe(2);
+        });
+
+    const req = httpMock.expectOne(request => request.method === 'GET' && request.url === url + '/');
+    req.flush(expectedData);
+  });
+
   it('should get a record detail', () => {
     const expectedData: any = {
       id: '1',

--- a/projects/rero/ng-core/src/lib/record/record.service.ts
+++ b/projects/rero/ng-core/src/lib/record/record.service.ts
@@ -101,6 +101,7 @@ export class RecordService {
    *                     a string or a list of string to filter with multiple values.
    * @param headers - HttpHeaders optional http header for the backend call.
    * @param sort - parameter for sorting records (eg. 'mostrecent' or '-mostrecent')
+   * @param facets - list of strings, define which aggregations/facets should be included into the response.
    */
   getRecords(
     type: string,
@@ -110,7 +111,8 @@ export class RecordService {
     aggregationsFilters: any[] = [],
     preFilters: object = {},
     headers: any = null,
-    sort: string = null
+    sort: string = null,
+    facets: string[] = []
   ): Observable<Record | Error> {
     // Build query string
     let httpParams = new HttpParams().set('q', query);
@@ -139,6 +141,10 @@ export class RecordService {
         httpParams = httpParams.append(key, value);
       }
     }
+
+    // facets management
+    //   if array `facets` is an empty array, no aggregations data will be included into response.s
+    httpParams = httpParams.append('facets', facets.join(','));
 
     // http request with headers
     return this._http


### PR DESCRIPTION
Adds the `facets` paramter to `getRecords` method. This parameter allow
to define which aggregation values should be included into API response.
By default, no aggregation should be include.

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>
Co-authored-by: Sébastien Delèze <sebastien.deleze@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
