### PR TITLE
records: hide type in tabs

### DIFF
--- a/projects/ng-core-tester/src/app/app-routing.module.ts
+++ b/projects/ng-core-tester/src/app/app-routing.module.ts
@@ -345,7 +345,8 @@ const routes: Routes = [
         },
         {
           key: 'organisations',
-          label: 'Organisations'
+          label: 'Organisations',
+          hideInTabs: false
         }
       ]
     }

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -16,8 +16,8 @@
 -->
 <ng-core-error [error]="error" *ngIf="error; else showComponent"></ng-core-error>
 <ng-template #showComponent>
-  <ul class="nav nav-tabs" *ngIf="types.length > 1">
-    <li class="nav-item" *ngFor="let type of types">
+  <ul class="nav nav-tabs" *ngIf="typesInTabs.length > 1">
+    <li class="nav-item" *ngFor="let type of typesInTabs">
       <a
         href="#"
         class="nav-link"
@@ -29,8 +29,8 @@
     </li>
   </ul>
   <div class="main-content">
-    <h5 *ngIf="types.length == 1 && showLabel">
-      {{ types[0].label | translate }}
+    <h5 *ngIf="typesInTabs.length == 1 && showLabel">
+      {{ typesInTabs[0].label | translate }}
     </h5>
     <ng-container *ngIf="hasNoRecord; else results">
       <div class="alert alert-info my-4">{{ emptyRecordMessage }}</div>

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -116,7 +116,8 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
       boundaryLinks?: boolean,
       maxSize?: number
     },
-    formFieldMap?: (field: FormlyFieldConfig, jsonSchema: JSONSchema7) => FormlyFieldConfig
+    formFieldMap?: (field: FormlyFieldConfig, jsonSchema: JSONSchema7) => FormlyFieldConfig,
+    hideInTabs?: boolean
   }[] = [{ key: 'documents', label: 'Documents' }];
 
   /**
@@ -521,6 +522,15 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   /**
+   * Returns the list of types that are displayed in tabs.
+   *
+   * @return List of types.
+   */
+  get typesInTabs(): Array<any> {
+    return this.types.filter((item) => item.hideInTabs !== true);
+  }
+
+  /**
    * Change number of items per page value.
    * @param event - Event, dom event triggered
    * @param size - number, new page size
@@ -916,6 +926,9 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     } else {
       this._config.aggregationsOrder = of([]);
     }
+
+    // reset aggregations
+    this.aggregations = null;
 
     // load search filters
     this.searchFilters = this._config.searchFilters


### PR DESCRIPTION
* Adds a `hideInTabs` configuration property to hide a resource from
the tabs in records search.
* Resets aggregations when the resource type is changed, for having
the aggregations for the right type.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>