### PR TITLE
search: load the default params once

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -161,26 +161,7 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
             }
           });
         }
-
-        // No default parameters found, we update the url to put them
-        if (
-          queryParams.has('q') === false ||
-          queryParams.has('size') === false ||
-          queryParams.has('page') === false ||
-          queryParams.has('sort') === false
-        ) {
-          this.updateUrl({
-            currentType: this.currentType,
-            q: this.q,
-            size: this.size,
-            page: this.page,
-            sort: this.sort,
-            aggregationsFilters,
-          });
-
-          return;
-        }
-
+        // update the facet filters given the URL params
         this._recordSearchService.setAggregationsFilters(aggregationsFilters);
       }
     );


### PR DESCRIPTION
* Loads the default prameters: size, query, etc. only once.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
