### PR TITLE
search: keep only the children filter

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
@@ -17,13 +17,13 @@
 <ul *ngIf="buckets" class="list-unstyled m-0 bucket-group">
   <li class="form-check bucket-item" *ngFor="let bucket of buckets|slice:0:bucketSize">
     <div class="d-flex flex-row bucket-data align-items-start" (click)="updateFilter(bucket)">
-      <input class="form-check-input" type="checkbox" [checked]="isSelected(bucket.key)"/>
+      <input class="form-check-input" [indeterminate]="bucket?.indeterminate" type="checkbox" [checked]="isSelected(bucket.key)"/>
       <a class="form-check-label">{{ getBucketName(bucket) }}</a>
       <span class="ml-auto bucket-count">
         <span class="bucket-count-badge">{{ bucket.doc_count }}</span>
       </span>
     </div>
-    <ng-container *ngIf="isSelected(bucket.key)">
+    <ng-container *ngIf="displayChildren(bucket)">
       <ng-core-record-search-aggregation-buckets
       *ngFor="let aggregation of bucketChildren[bucket.key]"
       [buckets]="aggregation.buckets"

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
@@ -26,7 +26,6 @@ import { AggregationsFilter, RecordSearchService } from '../../record-search.ser
   styleUrls: ['./buckets.component.scss']
 })
 export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
-
   // COMPONENT ATTRIBUTES ============================================================
   /** Buckets list for aggregation */
   @Input() buckets: Array<any>;
@@ -37,14 +36,15 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
 
   /** More and less on aggregation content (facet) */
   moreMode = true;
+
   /** Current selected values for the aggregation */
   aggregationsFilters: Array<AggregationsFilter> = [];
+
   /** Children of current bucket */
   bucketChildren: any = {};
 
   /** Subscription to aggregationsFilters observable */
   private _aggregationsFiltersSubscription: Subscription;
-
 
   // CONSTRUCTOR & HOOKS ==============================================================
   /**
@@ -95,7 +95,6 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
     this._aggregationsFiltersSubscription.unsubscribe();
   }
 
-
   // GETTERS & SETTERS =================================================================
   /**
    * Returns selected filters for the aggregation key.
@@ -105,17 +104,9 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
     const aggregationFilters = this.aggregationsFilters.find(
       (item: AggregationsFilter) => item.key === this.aggregationKey
     );
-    return (aggregationFilters === undefined)
+    return aggregationFilters === undefined
       ? []
       : aggregationFilters.values;
-  }
-
-  /**
-   * Get current language
-   * @return Current language
-   */
-  get language(): string {
-    return this._translateService.currentLang;
   }
 
   /**
@@ -124,7 +115,7 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
    */
   get bucketSize(): number {
     const size = this.buckets.length;
-    return (this.size === null || this.moreMode === false)
+    return this.size === null || this.moreMode === false
       ? size
       : this.size;
   }
@@ -139,6 +130,20 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   /**
+   * Do we need to display the children?
+   * @return true if we want to display the children
+   */
+  displayChildren(bucket): boolean {
+    return (
+      this.isSelected(bucket.key) ||
+      // not necessary but faster than hasChildrenFilter
+      bucket.indeterminate ||
+      // hasChildrenFilter is require to avoid blinks when a children is selected
+      this._recordSearchService.hasChildrenFilter(bucket)
+    );
+  }
+
+  /**
    * Update selected filters by adding or removing the given value and push
    * values to service.
    * @param bucket - string, filter value
@@ -150,23 +155,19 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
 
     if (index === -1) {
       // No filters exist for the aggregation.
-      this._recordSearchService.updateAggregationFilter(this.aggregationKey, [
-        bucket.key,
-      ]);
+      this._recordSearchService.updateAggregationFilter(this.aggregationKey, [bucket.key], bucket);
     } else {
       if (!this.aggregationsFilters[index].values.includes(bucket.key)) {
         // Bucket value is not yet selected, we add value to selected values.
         this.aggregationsFilters[index].values.push(bucket.key);
         this._recordSearchService.updateAggregationFilter(
           this.aggregationKey,
-          this.aggregationsFilters[index].values
+          this.aggregationsFilters[index].values,
+          bucket
         );
       } else {
         // Removes value from selected values and all children selected values.
-        this._recordSearchService.removeAggregationFilter(
-          this.aggregationKey,
-          bucket
-        );
+        this._recordSearchService.removeAggregationFilter(this.aggregationKey, bucket);
       }
     }
   }
@@ -178,14 +179,13 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
    */
   getBucketChildren(bucket: any): Array<any> {
     const children = [];
-    for (const k in bucket) {
-      if (bucket[k].buckets) {
-        children.push({
-          bucketSize: this.bucketSize,
-          key: k,
-          buckets: [...bucket[k].buckets],
-        });
-      }
+    for (const k of Object.keys(bucket).filter(key => bucket[key].buckets)) {
+      children.push({
+        aggregationKey: k,
+        bucketSize: this.bucketSize,
+        key: k,
+        buckets: bucket[k].buckets,
+      });
     }
     return children;
   }
@@ -195,9 +195,7 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
    * @return Boolean
    */
   displayMoreAndLessLink(): boolean {
-    return (this.size === null)
-      ? false
-      : this.buckets.length > this.size;
+    return this.size === null ? false : this.buckets.length > this.size;
   }
 
   /**
@@ -214,7 +212,8 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
     // For language aggregation, we transform language code to human readable
     // language.
     if (this.aggregationKey === 'language') {
-      return this._translateLanguage.translate(bucket.key, this.language);
+      return this._translateLanguage.translate(
+        bucket.key, this._translateService.currentLang);
     }
 
     // Simply translate the bucket key.

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -94,7 +94,7 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
     itemHeaders?: any,
     aggregationsName?: any,
     aggregationsOrder?: Array<string>,
-    aggregationsExpand?: Array<string>,
+    aggregationsExpand?: Array<string> | (() => Array<string>),
     aggregationsBucketSize?: number,
     pagination?: {
       boundaryLinks?: boolean,
@@ -205,7 +205,6 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
       size: parameters.size,
       sort: parameters.sort
     };
-
     for (const filter of parameters.aggregationsFilters) {
       // We need to loop over each value and insert it on beginning of the array
       // instead of assign values directly. Otherwise, angular router doesn't
@@ -215,7 +214,6 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
         queryParams[filter.key].unshift(value);
       }
     }
-
     this._router.navigate([this.getCurrentUrl(parameters.currentType)], { queryParams, relativeTo: this._route });
   }
 

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
@@ -286,11 +286,4 @@ describe('RecordSearchComponent', () => {
       expect(result.link).toBe('detail/100');
     });
   }));
-
-  it('should expand aggregation', waitForAsync(() => {
-    // recordUiServiceSpy.getResourceConfig.and.returnValue();
-    component['_config'] = { key: 'documents', aggregationsExpand: ['language'] };
-    expect(component.expandFacet('language')).toBeTruthy();
-    expect(component.expandFacet('author')).toBeFalsy();
-  }));
 });


### PR DESCRIPTION
Signed-off-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
* This PR is replaced by https://github.com/rero/ng-core/pull/503
* Removes the parent filters when a filter is selected in a hierarchical
  aggregation.
* Removes useless methods.
* The aggregationsExpand configuration can be a function.
* Adds indeterminate state to the parent filters.
* Stores the aggregationKey and parent properties in each bucket.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Screenshot
![image](https://user-images.githubusercontent.com/127249/171396470-12b42835-742d-41b0-9e12-77259ef8f437.png)

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
