### PR TITLE
search: keep only the children filter and add filter list

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -26,13 +26,7 @@
           "options": {
             "main": "projects/rero/ng-core/src/test.ts",
             "tsConfig": "projects/rero/ng-core/tsconfig.spec.json",
-            "karmaConfig": "projects/rero/ng-core/karma.conf.js",
-            "styles": [
-              "node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css"
-            ],
-            "scripts": [
-              "node_modules/bootstrap-slider/dist/bootstrap-slider.min.js"
-            ]
+            "karmaConfig": "projects/rero/ng-core/karma.conf.js"
           }
         },
         "lint": {
@@ -75,11 +69,7 @@
             ],
             "styles": [
               "projects/ng-core-tester/src/styles.scss",
-              "node_modules/ngx-bootstrap/datepicker/bs-datepicker.css",
-              "node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css"
-            ],
-            "scripts": [
-              "node_modules/bootstrap-slider/dist/bootstrap-slider.min.js"
+              "node_modules/ngx-bootstrap/datepicker/bs-datepicker.css"
             ]
           },
           "configurations": {
@@ -147,11 +137,7 @@
             ],
             "styles": [
               "projects/ng-core-tester/src/styles.scss",
-              "node_modules/ngx-bootstrap/datepicker/bs-datepicker.css",
-              "node_modules/bootstrap-slider/dist/css/bootstrap-slider.min.css"
-            ],
-            "scripts": [
-              "node_modules/bootstrap-slider/dist/bootstrap-slider.min.js"
+              "node_modules/ngx-bootstrap/datepicker/bs-datepicker.css"
             ]
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6084,11 +6084,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
       "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
     },
-    "bootstrap-slider": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-10.6.2.tgz",
-      "integrity": "sha512-8JTPZB9QVOdrGzYF3YgC3YW6ssfPeBvBwZnXffiZ7YH/zz1D0EKlZvmQsm/w3N0XjVNYQEoQ0ax+jHrErV4K1Q=="
-    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -12625,22 +12620,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-6.2.0.tgz",
       "integrity": "sha512-5WKHo6/ltkenw4UyXZwED8rODCgp2RGbWurzYzZsF/gH1JO5SN7TJ+AL6kXYk6XM42sDA2WhN9Db+ZPNjiyHnA=="
-    },
-    "ngx-bootstrap-slider": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap-slider/-/ngx-bootstrap-slider-1.9.0.tgz",
-      "integrity": "sha512-g99ji9Jl3Jqv42VHoV0tMCYd2QrZMuvprnPHWHpRt2zia7dD6MMJiJ5OHcGvh0VnUEq8RLaIGWaD1qDyHM2CTA==",
-      "requires": {
-        "bootstrap-slider": "^10.2.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-        }
-      }
     },
     "ngx-spinner": {
       "version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "minimist": ">=0.2.1",
     "moment": "^2.29.1",
     "ngx-bootstrap": "^6.2.0",
-    "ngx-bootstrap-slider": "^1.9.0",
     "ngx-spinner": "^10.0.1",
     "ngx-toastr": "^13.2.1",
     "npm-registry-fetch": "^9.0.0",

--- a/projects/rero/ng-core/ng-package.json
+++ b/projects/rero/ng-core/ng-package.json
@@ -21,7 +21,6 @@
       "ngx-bootstrap/modal": "ngx-bootstrap/modal",
       "ngx-bootstrap/pagination": "ngx-bootstrap/pagination",
       "ngx-bootstrap/popover": "ngx-bootstrap/popover",
-      "ngx-bootstrap-slider": "ngx-bootstrap-slider",
       "ngx-bootstrap/tooltip": "ngx-bootstrap/tooltip",
       "ngx-bootstrap/typeahead": "ngx-bootstrap/typeahead",
       "ngx-spinner": "ngx-spinner",

--- a/projects/rero/ng-core/package.json
+++ b/projects/rero/ng-core/package.json
@@ -26,7 +26,6 @@
     "crypto-js": "^3.3.0",
     "font-awesome": "^4.7.0",
     "ngx-bootstrap": "^6.2.0",
-    "ngx-bootstrap-slider": "^1.9.0",
     "ngx-spinner": "^10.0.1",
     "ngx-toastr": "^13.2.1",
     "simplemde": "^1.11.2"

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -21,7 +21,6 @@ import { FormlyBootstrapModule } from '@ngx-formly/bootstrap';
 import { FormlyModule, FORMLY_CONFIG } from '@ngx-formly/core';
 import { FormlySelectModule } from '@ngx-formly/core/select';
 import { TranslateService } from '@ngx-translate/core';
-import { NgxBootstrapSliderModule } from 'ngx-bootstrap-slider';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { BsDatepickerModule } from 'ngx-bootstrap/datepicker';
 import { PaginationModule } from 'ngx-bootstrap/pagination';
@@ -69,6 +68,8 @@ import { JsonComponent } from './search/result/item/json.component';
 import { RecordSearchResultComponent } from './search/result/record-search-result.component';
 import { RecordSearchResultDirective } from './search/result/record-search-result.directive';
 import { ExportButtonComponent } from './export-button/export-button.component';
+import { ListFiltersComponent } from './search/aggregation/list-filters/list-filters.component';
+import { BucketNamePipe } from './search/aggregation/bucket-name.pipe';
 
 @NgModule({
   declarations: [
@@ -107,7 +108,9 @@ import { ExportButtonComponent } from './export-button/export-button.component';
     CustomSelectFieldComponent,
     MarkdownFieldComponent,
     AggregationDateRangeComponent,
-    ExportButtonComponent
+    ExportButtonComponent,
+    ListFiltersComponent,
+    BucketNamePipe
   ],
   imports: [
     // NOTE : BrowserAnimationModule **should** be include in application core module.
@@ -172,7 +175,6 @@ import { ExportButtonComponent } from './export-button/export-button.component';
       ]
     }),
     FormlyBootstrapModule,
-    NgxBootstrapSliderModule,
     FormlySelectModule
   ],
   exports: [

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/bucket-name.pipe.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/bucket-name.pipe.spec.ts
@@ -1,0 +1,56 @@
+import { BucketNamePipe } from './bucket-name.pipe';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslateLanguageService } from '../../../translate/translate-language.service';
+import { TestBed } from '@angular/core/testing';
+
+describe('BucketNamePipe', () => {
+  let bucketNamePipe: BucketNamePipe;
+  let translateLanguageService: TranslateLanguageService;
+  let translateService: TranslateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        BucketNamePipe,
+        TranslateLanguageService,
+        TranslateService
+      ]
+    });
+    bucketNamePipe = TestBed.inject(BucketNamePipe);
+    translateLanguageService = TestBed.inject(TranslateLanguageService);
+    translateService = TestBed.inject(TranslateService);
+
+    translateService.setTranslation('fr', {
+      docsubtype_music: 'musique',
+      docmaintype_book: 'livre, texte'
+    });
+    translateService.use('fr');
+  });
+
+  it('create an instance', () => {
+    expect(bucketNamePipe).toBeTruthy();
+  });
+
+  it('should return musique', () => {
+    const bucket = { key: 'docsubtype_music', aggregationKey: 'document_subtype' };
+    expect(bucketNamePipe.transform(bucket, 'document_subtype')).toEqual('musique');
+  });
+
+  it('should return livre, texte', () => {
+    const bucket = { key: 'docmaintype_book', aggregationKey: 'document_type' };
+    expect(bucketNamePipe.transform(bucket, 'document_type')).toEqual('livre, texte');
+  });
+
+  it('should return allemand', () => {
+    const bucket = { key: 'ger', aggregationKey: 'language' };
+    expect(bucketNamePipe.transform(bucket, 'language')).toEqual('allemand');
+  });
+
+  it('should return Network of fictive libraries', () => {
+    const bucket = { key: '3', aggregationKey: 'organisation', name: 'Network of fictive libraries' };
+    expect(bucketNamePipe.transform(bucket, 'organisation')).toEqual('Network of fictive libraries');
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/bucket-name.pipe.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/bucket-name.pipe.ts
@@ -1,0 +1,44 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { TranslateLanguageService } from '../../../translate/translate-language.service';
+
+@Pipe({
+  name: 'bucketName'
+})
+export class BucketNamePipe implements PipeTransform {
+
+  /**
+   * Constructor.
+   *
+   * @param _translateLanguage - TranslateLanguage service.
+   * @param _translateService - Translate service.
+   */
+  constructor(
+    private _translateLanguage: TranslateLanguageService,
+    private _translateService: TranslateService
+    ) {}
+
+  /**
+   * Get bucket name.
+   *
+   * @param bucket - bucket Object.
+   * @param aggregationKey - key of aggregation.
+   * @return the translated name of filter
+   */
+  transform(bucket: any, aggregationKey: string): string {
+    // If a name is provided, we take directly that value.
+    if (bucket.name) {
+      return bucket.name;
+    }
+
+    // For language aggregation, we transform language code to human readable
+    // language.
+    if (aggregationKey === 'language') {
+      return this._translateLanguage.translate(bucket.key, this._translateService.currentLang);
+    }
+
+    // Simply translate the bucket key.
+    return this._translateService.instant(bucket.key);
+  }
+
+}

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/bucket-name.pipe.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/bucket-name.pipe.ts
@@ -33,12 +33,10 @@ export class BucketNamePipe implements PipeTransform {
 
     // For language aggregation, we transform language code to human readable
     // language.
-    if (aggregationKey === 'language') {
-      return this._translateLanguage.translate(bucket.key, this._translateService.currentLang);
-    }
+    return (aggregationKey === 'language')
+    ? this._translateLanguage.translate(bucket.key, this._translateService.currentLang)
+    : this._translateService.instant(bucket.key);
 
-    // Simply translate the bucket key.
-    return this._translateService.instant(bucket.key);
   }
 
 }

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
@@ -17,13 +17,13 @@
 <ul *ngIf="buckets" class="list-unstyled m-0 bucket-group">
   <li class="form-check bucket-item" *ngFor="let bucket of buckets|slice:0:bucketSize">
     <div class="d-flex flex-row bucket-data align-items-start" (click)="updateFilter(bucket)">
-      <input class="form-check-input" type="checkbox" [checked]="isSelected(bucket.key)"/>
+      <input class="form-check-input" [indeterminate]="bucket?.indeterminate" type="checkbox" [checked]="isSelected(bucket.key)"/>
       <a class="form-check-label">{{ getBucketName(bucket) }}</a>
       <span class="ml-auto bucket-count">
         <span class="bucket-count-badge">{{ bucket.doc_count }}</span>
       </span>
     </div>
-    <ng-container *ngIf="isSelected(bucket.key)">
+    <ng-container *ngIf="displayChildren(bucket)">
       <ng-core-record-search-aggregation-buckets
       *ngFor="let aggregation of bucketChildren[bucket.key]"
       [buckets]="aggregation.buckets"

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
@@ -18,7 +18,7 @@
   <li class="form-check bucket-item" *ngFor="let bucket of buckets|slice:0:bucketSize">
     <div class="d-flex flex-row bucket-data align-items-start" (click)="updateFilter(bucket)">
       <input class="form-check-input" [indeterminate]="bucket?.indeterminate" type="checkbox" [checked]="isSelected(bucket.key)"/>
-      <a class="form-check-label">{{ getBucketName(bucket) }}</a>
+      <a class="form-check-label">{{ bucket | bucketName: aggregationKey }}</a>
       <span class="ml-auto bucket-count">
         <span class="bucket-count-badge">{{ bucket.doc_count }}</span>
       </span>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
@@ -16,7 +16,7 @@
 -->
 <ul *ngIf="buckets" class="list-unstyled m-0 bucket-group">
   <li class="form-check bucket-item" *ngFor="let bucket of buckets|slice:0:bucketSize">
-    <div class="d-flex flex-row bucket-data align-items-start" (click)="updateFilter(bucket)">
+    <div class="d-flex flex-row bucket-data align-items-start" *ngIf="bucket.doc_count" (click)="updateFilter(bucket)">
       <input class="form-check-input" [indeterminate]="bucket?.indeterminate" type="checkbox" [checked]="isSelected(bucket.key)"/>
       <a class="form-check-label">{{ bucket | bucketName: aggregationKey }}</a>
       <span class="ml-auto bucket-count">

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.spec.ts
@@ -19,6 +19,7 @@ import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-tran
 import { TranslateLanguagePipe } from '../../../../translate/translate-language.pipe';
 import { RecordSearchService } from '../../record-search.service';
 import { BucketsComponent } from './buckets.component';
+import { BucketNamePipe } from '../bucket-name.pipe';
 
 describe('BucketsComponent', () => {
   let component: BucketsComponent;
@@ -28,7 +29,8 @@ describe('BucketsComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         BucketsComponent,
-        TranslateLanguagePipe
+        TranslateLanguagePipe,
+        BucketNamePipe
       ],
       imports: [
         TranslateModule.forRoot({

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
@@ -26,7 +26,6 @@ import { AggregationsFilter, RecordSearchService } from '../../record-search.ser
   styleUrls: ['./buckets.component.scss']
 })
 export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
-
   // COMPONENT ATTRIBUTES ============================================================
   /** Buckets list for aggregation */
   @Input() buckets: Array<any>;
@@ -37,14 +36,15 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
 
   /** More and less on aggregation content (facet) */
   moreMode = true;
+
   /** Current selected values for the aggregation */
   aggregationsFilters: Array<AggregationsFilter> = [];
+
   /** Children of current bucket */
   bucketChildren: any = {};
 
   /** Subscription to aggregationsFilters observable */
   private _aggregationsFiltersSubscription: Subscription;
-
 
   // CONSTRUCTOR & HOOKS ==============================================================
   /**
@@ -95,7 +95,6 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
     this._aggregationsFiltersSubscription.unsubscribe();
   }
 
-
   // GETTERS & SETTERS =================================================================
   /**
    * Returns selected filters for the aggregation key.
@@ -105,17 +104,9 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
     const aggregationFilters = this.aggregationsFilters.find(
       (item: AggregationsFilter) => item.key === this.aggregationKey
     );
-    return (aggregationFilters === undefined)
+    return aggregationFilters === undefined
       ? []
       : aggregationFilters.values;
-  }
-
-  /**
-   * Get current language
-   * @return Current language
-   */
-  get language(): string {
-    return this._translateService.currentLang;
   }
 
   /**
@@ -124,7 +115,7 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
    */
   get bucketSize(): number {
     const size = this.buckets.length;
-    return (this.size === null || this.moreMode === false)
+    return this.size === null || this.moreMode === false
       ? size
       : this.size;
   }
@@ -139,6 +130,20 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   /**
+   * Do we need to display the children?
+   * @return true if we want to display the children
+   */
+  displayChildren(bucket): boolean {
+    return (
+      this.isSelected(bucket.key) ||
+      // not necessary but faster than hasChildrenFilter
+      bucket.indeterminate ||
+      // hasChildrenFilter is require to avoid blinks when a children is selected
+      this._recordSearchService.hasChildrenFilter(bucket)
+    );
+  }
+
+  /**
    * Update selected filters by adding or removing the given value and push
    * values to service.
    * @param bucket - string, filter value
@@ -150,23 +155,19 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
 
     if (index === -1) {
       // No filters exist for the aggregation.
-      this._recordSearchService.updateAggregationFilter(this.aggregationKey, [
-        bucket.key,
-      ]);
+      this._recordSearchService.updateAggregationFilter(this.aggregationKey, [bucket.key], bucket);
     } else {
       if (!this.aggregationsFilters[index].values.includes(bucket.key)) {
         // Bucket value is not yet selected, we add value to selected values.
         this.aggregationsFilters[index].values.push(bucket.key);
         this._recordSearchService.updateAggregationFilter(
           this.aggregationKey,
-          this.aggregationsFilters[index].values
+          this.aggregationsFilters[index].values,
+          bucket
         );
       } else {
         // Removes value from selected values and all children selected values.
-        this._recordSearchService.removeAggregationFilter(
-          this.aggregationKey,
-          bucket
-        );
+        this._recordSearchService.removeAggregationFilter(this.aggregationKey, bucket);
       }
     }
   }
@@ -178,14 +179,13 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
    */
   getBucketChildren(bucket: any): Array<any> {
     const children = [];
-    for (const k in bucket) {
-      if (bucket[k].buckets) {
-        children.push({
-          bucketSize: this.bucketSize,
-          key: k,
-          buckets: [...bucket[k].buckets],
-        });
-      }
+    for (const k of Object.keys(bucket).filter(key => bucket[key].buckets)) {
+      children.push({
+        aggregationKey: k,
+        bucketSize: this.bucketSize,
+        key: k,
+        buckets: bucket[k].buckets,
+      });
     }
     return children;
   }
@@ -195,9 +195,7 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
    * @return Boolean
    */
   displayMoreAndLessLink(): boolean {
-    return (this.size === null)
-      ? false
-      : this.buckets.length > this.size;
+    return this.size === null ? false : this.buckets.length > this.size;
   }
 
   /**
@@ -214,7 +212,8 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
     // For language aggregation, we transform language code to human readable
     // language.
     if (this.aggregationKey === 'language') {
-      return this._translateLanguage.translate(bucket.key, this.language);
+      return this._translateLanguage.translate(
+        bucket.key, this._translateService.currentLang);
     }
 
     // Simply translate the bucket key.

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
@@ -195,28 +195,9 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
    * @return Boolean
    */
   displayMoreAndLessLink(): boolean {
-    return this.size === null ? false : this.buckets.length > this.size;
+    return (this.size === null)
+      ? false
+      : this.buckets.length > this.size;
   }
 
-  /**
-   * Return the name displayed for the bucket.
-   * @param bucket Bucket to get the name from.
-   * @return Displayed name of the bucket.
-   */
-  getBucketName(bucket: any): string {
-    // If a name is provided, we take directly that value.
-    if (bucket.name) {
-      return bucket.name;
-    }
-
-    // For language aggregation, we transform language code to human readable
-    // language.
-    if (this.aggregationKey === 'language') {
-      return this._translateLanguage.translate(
-        bucket.key, this._translateService.currentLang);
-    }
-
-    // Simply translate the bucket key.
-    return this._translateService.instant(bucket.key);
-  }
 }

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
@@ -197,7 +197,20 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
   displayMoreAndLessLink(): boolean {
     return (this.size === null)
       ? false
-      : this.buckets.length > this.size;
+      : this.bucketsLength() > this.size;
   }
 
+  /**
+   * Count buckets with non zero doc_count
+   * @return length of buckets
+   */
+  bucketsLength(): number {
+    let bucketLength = 0;
+    for (const bucket of this.buckets) {
+      if (bucket.doc_count){
+        bucketLength += 1;
+      }
+    }
+    return bucketLength;
+  }
 }

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.html
@@ -1,0 +1,8 @@
+<ul *ngIf="filters?.length > 0" class="pl-0">
+    <li id="filter" *ngFor="let filter of filters" class="list-unstyled mb-1">
+        <button (click)="remove(filter)" type="button" class="btn btn-outline-secondary btn-sm" 
+        data-toggle="button" aria-pressed="false" autocomplete="off">
+            {{filter | bucketName: filter.aggregationKey }} <i class="fa fa-close"></i>
+        </button>
+    </li>
+</ul>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.html
@@ -1,6 +1,6 @@
-<ul *ngIf="filters?.length > 0" class="pl-0">
-    <li id="filter" *ngFor="let filter of filters" class="list-unstyled mb-1">
-        <button (click)="remove(filter)" type="button" class="btn btn-outline-secondary btn-sm" 
+<ul id="filters" *ngIf="filters?.length > 0" class="pl-0">
+    <li *ngFor="let filter of filters" class="d-inline list-unstyled pr-2">
+        <button (click)="remove(filter)" type="button" class="btn btn-outline-secondary btn-sm mb-2"
         data-toggle="button" aria-pressed="false" autocomplete="off">
             {{filter | bucketName: filter.aggregationKey }} <i class="fa fa-close"></i>
         </button>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.spec.ts
@@ -1,0 +1,59 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ListFiltersComponent } from './list-filters.component';
+import { BucketNamePipe } from '../bucket-name.pipe';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+describe('ListFiltersComponent', () => {
+  let component: ListFiltersComponent;
+  let fixture: ComponentFixture<ListFiltersComponent>;
+  let translateService: TranslateService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot()
+      ],
+      declarations: [
+        ListFiltersComponent,
+        BucketNamePipe
+      ]
+    })
+    .compileComponents();
+    translateService = TestBed.inject(TranslateService);
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ListFiltersComponent);
+    component = fixture.componentInstance;
+    component.filters = [
+      { key: 'on_shelf', aggregationKey: 'status' },
+      { key: 'docmaintype_serial', aggregationKey: 'document_type' }
+    ];
+    translateService.setTranslation('en', {
+      on_shelf: 'available',
+      docmaintype_serial: 'serial'
+    });
+    translateService.use('en');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display 2 buttons', () => {
+    const buttons = fixture.debugElement.nativeElement.querySelectorAll('li#filter > button');
+    expect(buttons.length).toBe(2);
+  });
+
+  it('should display button available', () => {
+    const buttons = fixture.debugElement.nativeElement.querySelectorAll('li#filter > button');
+    expect(buttons[0].innerHTML).toContain('available');
+  });
+
+  it('should display button serial', () => {
+    const buttons = fixture.debugElement.nativeElement.querySelectorAll('li#filter > button');
+    expect(buttons[1].innerHTML).toContain('serial');
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.spec.ts
@@ -43,17 +43,17 @@ describe('ListFiltersComponent', () => {
   });
 
   it('should display 2 buttons', () => {
-    const buttons = fixture.debugElement.nativeElement.querySelectorAll('li#filter > button');
+    const buttons = fixture.debugElement.nativeElement.querySelectorAll('ul#filters li > button');
     expect(buttons.length).toBe(2);
   });
 
   it('should display button available', () => {
-    const buttons = fixture.debugElement.nativeElement.querySelectorAll('li#filter > button');
+    const buttons = fixture.debugElement.nativeElement.querySelectorAll('ul#filters li > button');
     expect(buttons[0].innerHTML).toContain('available');
   });
 
   it('should display button serial', () => {
-    const buttons = fixture.debugElement.nativeElement.querySelectorAll('li#filter > button');
+    const buttons = fixture.debugElement.nativeElement.querySelectorAll('ul#filters li > button');
     expect(buttons[1].innerHTML).toContain('serial');
   });
 });

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.ts
@@ -1,0 +1,100 @@
+import { ChangeDetectorRef, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { RecordSearchService } from '../../record-search.service';
+
+@Component({
+  selector: 'ng-core-list-filters',
+  templateUrl: './list-filters.component.html'
+})
+export class ListFiltersComponent implements OnChanges {
+  /**
+   * All aggregations
+   */
+  @Input()
+  aggregations;
+
+  /**
+   * Selected aggregations filters
+   */
+  @Input()
+  aggregationsFilters;
+
+  /**
+   * List of selected filters
+   */
+  filters: Array<any> = [];
+
+  /**
+   * Constructor.
+   *
+   * @param _recordSearchService - RecordSearch service.
+   * @param ref - ChangeDetectorRef.
+   */
+  constructor(
+    private _recordSearchService: RecordSearchService,
+    private ref: ChangeDetectorRef
+  ){ }
+
+  /**
+   * Update list of filters on changes.
+   *
+   * @param changes - SimpleChanges.
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes?.aggregationsFilters) {
+      this.ref.detach();
+      this.filters = [];
+
+      changes.aggregationsFilters.currentValue.map(filter => {
+        this.filters = this.filters.concat(
+          filter.values.filter(v => v !== 'true')
+          .map( value => {
+            return {key: value, aggregationKey: filter.key};
+          })
+          );
+      });
+    }
+
+    if (changes?.aggregations) {
+      changes.aggregations.currentValue.map(item => {
+          this.getFilterNames(item.value.buckets);
+      });
+      this.ref.reattach();
+    }
+
+  }
+
+  /**
+   * Get displayed name of bucket
+   * and fill in filters list.
+   *
+   * @param bucket - Bucket to get the name from.
+   */
+  getFilterNames(buckets) {
+    if (buckets.length === 0){
+      return;
+    }
+    buckets.map(bucket => {
+      for (const k in bucket) {
+        if (bucket[k].buckets) {
+          this.getFilterNames(bucket[k].buckets);
+        }
+      }
+      if (bucket.name) {
+        const index = this.filters.findIndex(filter => filter.key === bucket.key && filter.aggregationKey === bucket.aggregationKey);
+        if (index > -1) {
+          this.filters[index].name = bucket.name;
+          this.filters[index] = {...this.filters[index]};
+        }
+      }
+    });
+  }
+
+  /**
+   * Remove filter.
+   *
+   * @param filter - the filter to remove
+   */
+  remove(filter): void {
+    this._recordSearchService.removeFilter(filter.aggregationKey, filter.key, true);
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.html
@@ -14,7 +14,6 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<mv-slider [(value)]="range" [min]="min" [max]="max" [range]="true" [step]="step"></mv-slider>
 <div class="row mt-3">
   <div class="col-12 col-sm-6">
     <input type="number" [min]="min" [max]="max" class="form-control form-control-sm text-center" [(ngModel)]="range[0]" #ctrl="ngModel">

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.html
@@ -16,15 +16,19 @@
 -->
 <div class="row mt-3">
   <div class="col-12 col-sm-6">
-    <input type="number" [min]="min" [max]="max" class="form-control form-control-sm text-center" [(ngModel)]="range[0]" #ctrl="ngModel">
+    <input type="number" [min]="min" [max]="max" class="form-control form-control-sm text-center"
+    (keyup.enter)="$event.preventDefault(); updateFilter()" [(ngModel)]="range[0]" #ctrl="ngModel">
   </div>
   <div class="col-12 col-sm-6">
-    <input type="number" [min]="min" [max]="max" class="form-control form-control-sm text-center" [(ngModel)]="range[1]" #ctrl="ngModel">
+    <input type="number" [min]="min" [max]="max" class="form-control form-control-sm text-center"
+    (keyup.enter)="$event.preventDefault(); updateFilter()" [(ngModel)]="range[1]" #ctrl="ngModel">
   </div>
 </div>
 <div class="text-center mt-2">
   <small>
-    <a href class="mx-3" (click)="$event.preventDefault(); updateFilter()" translate>Show</a>
-    <a href class="mx-3" (click)="$event.preventDefault(); clearFilter()" *ngIf="hasQueryParam" translate>Clear filter</a>
+    <a href class="mx-1 btn btn-outline-primary btn-sm" (click)="$event.preventDefault(); updateFilter()"
+    translate>Apply</a>
+    <a href class="mx-1 btn btn-outline-primary btn-sm" (click)="$event.preventDefault(); clearFilter()"
+    *ngIf="hasQueryParam" translate>Clear filter</a>
   </small>
 </div>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.ts
@@ -101,9 +101,8 @@ export class AggregationSliderComponent implements OnDestroy, OnInit {
    * Update aggregation filter.
    */
   updateFilter() {
-    if (!this.range[0] || !this.range[1]) {
-      return;
-    }
+    if (!this.range[0] || this.range[0] < this.min) { this.range[0] = this.min; }
+    if (!this.range[1] || this.range[1] > this.max) { this.range[1] = this.max; }
 
     this._recordSearchService.updateAggregationFilter(this.key, [
       `${this.range[0]}--${this.range[1]}`,

--- a/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search-page.component.ts
@@ -94,7 +94,7 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
     itemHeaders?: any,
     aggregationsName?: any,
     aggregationsOrder?: Array<string>,
-    aggregationsExpand?: Array<string>,
+    aggregationsExpand?: Array<string> | (() => Array<string>),
     aggregationsBucketSize?: number,
     pagination?: {
       boundaryLinks?: boolean,
@@ -205,7 +205,6 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
       size: parameters.size,
       sort: parameters.sort
     };
-
     for (const filter of parameters.aggregationsFilters) {
       // We need to loop over each value and insert it on beginning of the array
       // instead of assign values directly. Otherwise, angular router doesn't
@@ -215,7 +214,6 @@ export class RecordSearchPageComponent implements OnInit, OnDestroy {
         queryParams[filter.key].unshift(value);
       }
     }
-
     this._router.navigate([this.getCurrentUrl(parameters.currentType)], { queryParams, relativeTo: this._route });
   }
 

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -104,6 +104,11 @@
         </div>
       </div>
       <div class="row">
+        <ng-core-list-filters
+          class="col-12"
+          [aggregations]="aggregations"
+          [aggregationsFilters]="aggregationsFilters">
+        </ng-core-list-filters>
         <div *ngIf="(aggregations && aggregations.length) || searchFields.length > 0  || searchFilters.length > 0"
              class="col-sm-12 col-md-5 col-lg-3 order-2 order-md-1">
           <div *ngIf="searchFields.length > 0 && q"

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -107,12 +107,14 @@
         <ng-core-list-filters
           class="col-12"
           [aggregations]="aggregations"
-          [aggregationsFilters]="aggregationsFilters">
+          [aggregationsFilters]="aggregationsFilters"
+          [searchFilters]="searchFilters"
+          >
         </ng-core-list-filters>
         <div *ngIf="(aggregations && aggregations.length) || searchFields.length > 0  || searchFilters.length > 0"
-             class="col-sm-12 col-md-5 col-lg-3 order-2 order-md-1">
+            class="col-sm-12 col-md-5 col-lg-3 order-2 order-md-1">
           <div *ngIf="searchFields.length > 0 && q"
-               class="btn-group btn-block mb-3" dropdown>
+              class="btn-group btn-block mb-3" dropdown>
             <button *ngIf="searchFields.length === 1; else fieldsDropdown"
                     class="btn btn-outline-primary btn-sm text-left"
                     [ngClass]="{ active: selectedSearchFields[0] === searchFields[0] }"
@@ -136,34 +138,54 @@
               </ul>
             </ng-template>
           </div>
+
           <ng-container *ngIf="searchFilters">
             <div class="mb-2">
-              <div class="custom-control custom-switch" *ngFor="let searchfilter of searchFilters">
-                <input
-                  type="checkbox"
-                  class="custom-control-input"
-                  id="customSwitch-{{ searchfilter.filter }}"
-                  (click)="searchFilter(searchfilter)"
-                  [checked]="isFilterActive(searchfilter)"
-                >
-                <label class="custom-control-label" for="customSwitch-{{ searchfilter.filter }}">{{ searchfilter.label }}</label>
-                <ng-container *ngIf="searchfilter.url">
-                  <ng-container *ngIf="searchfilter.url.external; else internal">
-                    <a
-                      class="ml-1 text-dark"
-                      [title]="searchfilter.url.title"
-                      [href]="searchfilter.url.link"
-                      [target]="searchfilter.url.target"
+              <div *ngFor="let searchfilter of searchFilters">
+                <!-- filters online and not_online -->
+                <div class="mt-2" *ngIf="showSearchFilters() && searchfilter.filter == 'online'">{{ 'Show only:' | translate }}</div>
+                <ng-container  *ngIf="searchfilter.filter == 'online' || searchfilter.filter == 'not_online'; else otherSearchFilters">
+                  <div class="custom-control custom-switch" *ngIf="showSearchFilters()">
+                    <input
+                      type="checkbox"
+                      class="custom-control-input"
+                      id="customSwitch-{{ searchfilter.filter }}"
+                      (click)="searchFilter(searchfilter)"
+                      [checked]="isFilterActive(searchfilter)"
                     >
-                      <i class="fa fa-info-circle" aria-hidden="true"></i>
-                    </a>
-                  </ng-container>
-                  <ng-template #internal>
-                    <a class="ml-1 text-dark" [title]="searchfilter.url.title" [routerLink]="searchfilter.url.routerLink">
-                      <i class="fa fa-info-circle" aria-hidden="true"></i>
-                    </a>
-                  </ng-template>
+                    <label class="custom-control-label" for="customSwitch-{{ searchfilter.filter }}">{{ searchfilter.label }}</label>
+                  </div>
                 </ng-container>
+                <!-- other types of filters -->
+                <ng-template #otherSearchFilters>
+                  <div class="custom-control custom-switch">
+                    <input
+                      type="checkbox"
+                      class="custom-control-input"
+                      id="customSwitch-{{ searchfilter.filter }}"
+                      (click)="searchFilter(searchfilter)"
+                      [checked]="isFilterActive(searchfilter)"
+                    >
+                    <label class="custom-control-label" for="customSwitch-{{ searchfilter.filter }}">{{ searchfilter.label }}</label>
+                    <ng-container *ngIf="searchfilter.url">
+                      <ng-container *ngIf="searchfilter.url.external; else internal">
+                        <a
+                          class="ml-1 text-dark"
+                          [title]="searchfilter.url.title"
+                          [href]="searchfilter.url.link"
+                          [target]="searchfilter.url.target"
+                        >
+                          <i class="fa fa-info-circle" aria-hidden="true"></i>
+                        </a>
+                      </ng-container>
+                      <ng-template #internal>
+                        <a class="ml-1 text-dark" [title]="searchfilter.url.title" [routerLink]="searchfilter.url.routerLink">
+                          <i class="fa fa-info-circle" aria-hidden="true"></i>
+                        </a>
+                      </ng-template>
+                    </ng-container>
+                  </div>
+                </ng-template>
               </div>
             </div>
           </ng-container>

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.spec.ts
@@ -286,11 +286,4 @@ describe('RecordSearchComponent', () => {
       expect(result.link).toBe('detail/100');
     });
   }));
-
-  it('should expand aggregation', waitForAsync(() => {
-    // recordUiServiceSpy.getResourceConfig.and.returnValue();
-    component['_config'] = { key: 'documents', aggregationsExpand: ['language'] };
-    expect(component.expandFacet('language')).toBeTruthy();
-    expect(component.expandFacet('author')).toBeFalsy();
-  }));
 });

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -559,7 +559,9 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
    * @returns True if no record is found and no search query is done.
    */
   get hasNoRecord(): boolean {
-    return !this.q && this.records.length === 0 && !this.showEmptySearchMessage;
+    return (this._config.showFacetsIfNoResults)
+    ? false
+    : !this.q && this.records.length === 0 && !this.showEmptySearchMessage;
   }
 
   /**
@@ -914,7 +916,6 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     const aggregation = this.aggregations.find((item: any) => item.key === event.key);
-
     // No aggregation found or buckets are already loaded.
     if (!aggregation || aggregation.loaded) {
       return;
@@ -963,6 +964,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
         preFilters[key] = value;
       }
     }
+
     return this._recordService.getRecords(
       this._currentIndex(),
       q,
@@ -1160,6 +1162,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     }
     aggregation.value.buckets.map(bucket => this.processBuckets(bucket, aggregation.key));
     aggregation.loaded = true;
+
   }
 
   /**
@@ -1217,5 +1220,16 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
         }
       });
     }
+  }
+
+  /**
+   * Check if to show search filters.
+   * @returns boolean
+   */
+  showSearchFilters(): boolean {
+    if (this._config.allowEmptySearch === false && !this.q) {
+      return false;
+    }
+    return true;
   }
 }

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -310,7 +310,6 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
         (records: Record) => {
           this.hits = records.hits;
           this._spinner.hide();
-
           // Apply filters
           this.aggregations$(records.aggregations).subscribe((aggregations: any) => {
             for (const agg of this.aggregations) {
@@ -322,7 +321,8 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
               }
             }
           });
-
+          // Required to fire onChange event
+          this.aggregations = [...this.aggregations];
           this._emitNewParameters();
           this.recordsSearched.emit({ type: this.currentType, records });
           // reload export options
@@ -926,6 +926,8 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
         if (aggregations[event.key]) {
           this._mapAggregation(aggregation, aggregations[event.key]);
         }
+        // Required to fire onChange event
+        this.aggregations = [...this.aggregations];
         this._spinner.hide();
       });
 
@@ -1170,12 +1172,12 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
   processBuckets(bucket, aggregationKey): boolean {
     // checkbox indeterminate state
     bucket.indeterminate = false;
+    bucket.aggregationKey = aggregationKey;
     for (const k of Object.keys(bucket).filter(key => bucket[key].buckets)) {
       for (const childBucket of bucket[k].buckets) {
           // store the parent: usefull to remove parent filters
           childBucket.parent = bucket;
           // store the aggregation key as we re-organize the bucket structure
-          bucket.aggregationKey = aggregationKey;
           bucket.indeterminate ||= this._recordSearchService.hasFilter(k, childBucket.key);
           // do not change the order of the boolean expression to force processBucket over all
           // recursion steps

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.ts
@@ -122,7 +122,7 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     itemHeaders?: any,
     aggregationsName?: any,
     aggregationsOrder?: Array<string>,
-    aggregationsExpand?: Array<string>,
+    aggregationsExpand?: Array<string> | (() => Array<string>),
     aggregationsBucketSize?: number,
     showSearchInput?: boolean,
     pagination?: {
@@ -289,7 +289,11 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
           return this._config.aggregationsOrder.pipe(
             tap((aggregations: string[]) => {
               this.aggregations = aggregations.map((key: any) => {
-                const expanded = (this._config.aggregationsExpand || []).includes(key);
+                let aggregationsExpandCfg = this._config.aggregationsExpand;
+                if (typeof aggregationsExpandCfg === 'function') {
+                  aggregationsExpandCfg = aggregationsExpandCfg();
+                }
+                const expanded = (aggregationsExpandCfg || []).includes(key);
                 return {
                   key: key.key || key,
                   bucketSize: this._config.aggregationsBucketSize || null,
@@ -309,15 +313,14 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
 
           // Apply filters
           this.aggregations$(records.aggregations).subscribe((aggregations: any) => {
-            this.aggregations.forEach((agg: Aggregation) => {
-              // Mark all aggregations as not loaded.
+            for (const agg of this.aggregations) {
+              // reset aggregations
               agg.loaded = false;
               agg.value.buckets = [];
-              const recordsAggregationKey = Object.keys(aggregations).find((key: string) => key === agg.key);
-              if (recordsAggregationKey) {
-                this._mapAggregation(agg, aggregations[recordsAggregationKey]);
+              if (agg.key in aggregations) {
+                this._mapAggregation(agg, aggregations[agg.key]);
               }
-            });
+            }
           });
 
           this._emitNewParameters();
@@ -432,7 +435,9 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
    */
   get paginationMaxSize(): number {
     const paginationConfig = this._getResourceConfig('pagination', {});
-    return ('maxSize' in paginationConfig) ? paginationConfig.maxSize : 5;
+    return ('maxSize' in paginationConfig)
+      ? paginationConfig.maxSize
+      : 5;
   }
 
   /**
@@ -441,7 +446,9 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
    * @return list of metadata results.
    */
   get records(): Array<any> {
-    return this.hits && this.hits.hits ? this.hits.hits : [];
+    return this.hits && this.hits.hits
+      ? this.hits.hits
+      : [];
   }
 
   /**
@@ -450,7 +457,9 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
    * @return integer representing the number of results.
    */
   get total(): number {
-    return this.hits && this.hits.total ? this._recordService.totalHits(this.hits.total) : 0;
+    return this.hits && this.hits.total
+      ? this._recordService.totalHits(this.hits.total)
+      : 0;
   }
 
   /**
@@ -755,16 +764,6 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
       : this._translateService.instant('Too many items. Should be less than {{max}}.',
         { max: RecordService.MAX_REST_RESULTS_SIZE }
       );
-  }
-
-  /**
-   * Show or hide facet section
-   * @param key facet key
-   * @return Boolean
-   */
-  expandFacet(key: string): boolean {
-    const expandConfig = ('aggregationsExpand' in this._config) ? this._config.aggregationsExpand : [];
-    return expandConfig.includes(key);
   }
 
   /**
@@ -1105,7 +1104,9 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     if (this._config == null) {
       return null;
     }
-    return this._config.index ? this._config.index : this._config.key;
+    return this._config.index
+      ? this._config.index
+      : this._config.key;
   }
 
   /**
@@ -1155,7 +1156,33 @@ export class RecordSearchComponent implements OnInit, OnChanges, OnDestroy {
     if (recordsAggregation.doc_count != null) {
       aggregation.doc_count = recordsAggregation.doc_count;
     }
+    aggregation.value.buckets.map(bucket => this.processBuckets(bucket, aggregation.key));
     aggregation.loaded = true;
+  }
+
+  /**
+   * Enrich the bucket with several properties: indeterminate, parent, aggregationKey.
+   *
+   * @param bucket elastic bucket to process
+   * @param aggregationKey bucket parent key
+   * @returns the indeterninate state of the bucket
+   */
+  processBuckets(bucket, aggregationKey): boolean {
+    // checkbox indeterminate state
+    bucket.indeterminate = false;
+    for (const k of Object.keys(bucket).filter(key => bucket[key].buckets)) {
+      for (const childBucket of bucket[k].buckets) {
+          // store the parent: usefull to remove parent filters
+          childBucket.parent = bucket;
+          // store the aggregation key as we re-organize the bucket structure
+          bucket.aggregationKey = aggregationKey;
+          bucket.indeterminate ||= this._recordSearchService.hasFilter(k, childBucket.key);
+          // do not change the order of the boolean expression to force processBucket over all
+          // recursion steps
+          bucket.indeterminate = this.processBuckets(childBucket, k) || bucket.indeterminate;
+        }
+    }
+    return bucket.indeterminate;
   }
 
   /**

--- a/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
@@ -125,7 +125,7 @@ export class RecordSearchService {
    * @param key filter name
    * @param value filter value
    */
-  removeFilter(key, value) {
+  removeFilter(key, value, emit = false) {
     const filter = this._aggregationsFilters.find(item => item.key === key);
     if (filter) {
       filter.values = filter.values.filter(item => item !== value);
@@ -133,6 +133,9 @@ export class RecordSearchService {
       if (filter.values.length === 0) {
         this._aggregationsFilters = this._aggregationsFilters.filter(item => item.key !== filter.key);
       }
+    }
+    if (emit) {
+      this._aggregationsFiltersSubject.next(cloneDeep(this._aggregationsFilters));
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

* Removes the parent filters when a filter is selected in a hierarchical
  aggregation.
* Removes useless methods.
* The aggregationsExpand configuration can be a function.
* Adds indeterminate state to the parent filters.
* Stores the aggregationKey and parent properties in each bucket.
* Add filter list
* Removed ngx-bootstrap-slider
* Display banner no results in current page

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
Co-Authored-by: Valeria Granata <valeria@chaw.com>

## Screenshot
![image](https://user-images.githubusercontent.com/127249/171396470-12b42835-742d-41b0-9e12-77259ef8f437.png)

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
