### PR TITLE
search : add customizable areas into search result page

### DIFF
--- a/projects/rero/ng-core/src/lib/record/record.ts
+++ b/projects/rero/ng-core/src/lib/record/record.ts
@@ -80,9 +80,7 @@ export interface SearchFilter {
   };
 }
 
-/**
- * Interface for an aggregation
- */
+/** Interfaces for an aggregation */
 export interface Aggregation {
   key: string;
   bucketSize: any;
@@ -91,6 +89,28 @@ export interface Aggregation {
   loaded?: boolean;
   doc_count?: number;
   type?: string;
-  config?: any;
+  config?: AggregationConfig;
   name?: string;
+}
+
+/**
+ * Interface to describe an aggregation configuration
+ *
+ * Additionally to aggregation buckets, an aggregation configuration object could be
+ * provided to control the aggregation display behavior. The configuration keys depends
+ * on the aggregation type.
+ *
+ * attributes are :
+ *   @attribute type - string: the type of aggregation (ex date-range, sum, date-histogram, ...)
+ *   @attribute min - number: the minimum value into the aggregation buckets.
+ *   @attribute max - number: the maximum value into the aggregation buckets.
+ *   @attribute step - number: the step uses between to value.
+ *   @attributes any additional/not known attributes.
+ */
+export interface AggregationConfig {
+  type?: string,
+  min?: number,
+  max?: number,
+  step?: number
+  [x: string | number | symbol]: unknown  // allow additional properties
 }

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.html
@@ -35,7 +35,7 @@
         </button>
       </h5>
     </div>
-    <div class="collapse" [class.show]="showAggregation()">
+    <div class="collapse" [class.show]="isAggregationDisplayed">
       <div class="card-body pl-3 pr-2 py-3">
         <ng-container [ngSwitch]="aggregation.type">
           <!-- Range -->

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/aggregation.component.ts
@@ -22,17 +22,16 @@ import { Aggregation } from '../../record';
   templateUrl: './aggregation.component.html',
 })
 export class RecordSearchAggregationComponent {
+  // COMPONENT ATTRIBUTES =====================================================
   /** Aggregation data */
   @Input() aggregation: Aggregation;
-
   /** Current selected values */
   @Input() aggregationsFilters = [];
 
-  /**
-   * Output event when aggregation is clicked.
-   */
+  /** Output event when aggregation is clicked. */
   @Output() aggregationClicked = new EventEmitter<any>();
 
+  // GETTER & SETTER ==========================================================
   /**
    * Returns aggregations filters corresponding to the aggregation key.
    * @return List of aggregation filters
@@ -42,26 +41,23 @@ export class RecordSearchAggregationComponent {
     return aggregationFilters === undefined ? [] : aggregationFilters.values;
   }
 
-  /**
-   * Display buckets for the aggregation or not.
-   * @return Boolean
-   */
-  showAggregation(): boolean {
+  /** Is the aggregation content should be displayed. */
+  get isAggregationDisplayed(): boolean {
     return this.aggregation.expanded || this.aggregationFilters.length > 0;
   }
+
+  // PUBLIC COMPONENTS ========================================================
 
   /**
    * Method called when the title of an aggregation is clicked.
    */
   toggleVisibility(): void {
-    // if filters are seleted, we do nothing.
+    // if filters are selected, we do nothing.
     if (this.aggregationFilters.length > 0) {
       return;
     }
-
-    // Toggle expanded.
+    // Toggle aggregation expanded attribute
     this.aggregation.expanded = !this.aggregation.expanded;
-
     // Emit the value to parent.
     this.aggregationClicked.emit({
       key: this.aggregation.key,

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.html
@@ -36,7 +36,7 @@
     </ng-container>
   </li>
 </ul>
-<div *ngIf="displayMoreAndLessLink()">
+<div *ngIf="displayMoreAndLessLink">
   <button class="btn btn-link ml-2"
     (click)="moreMode = !moreMode">{{ (moreMode ? 'more…' : 'less…') | translate }}</button>
 </div>

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/list-filters/list-filters.component.ts
@@ -115,10 +115,9 @@ export class ListFiltersComponent implements OnChanges {
    * @param buckets - Bucket to get the name from.
    */
   getFilterNames(buckets: any) {
-    if (buckets.length === 0) {
+    if (!buckets || buckets.length === 0) {
       return;
     }
-
     buckets.map((bucket: any) => {
       for (const k in bucket) {
         if (bucket[k].buckets) {

--- a/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/slider/slider.component.ts
@@ -24,94 +24,76 @@ import { Subscription } from 'rxjs';
   templateUrl: './slider.component.html',
 })
 export class AggregationSliderComponent implements OnDestroy, OnInit {
-  // Aggregation key.
-  @Input()
-  key: string;
 
-  // Buckets list
-  @Input()
-  buckets: Array<any>;
+  // COMPONENT ATTRIBUTES =====================================================
+  /** The aggregation key. */
+  @Input() key: string;
+  /** Buckets list */
+  @Input() buckets: Array<any>;
+  /** The minimum value */
+  @Input() min = 1;
+  /** The maximum value */
+  @Input() max = 1000;
+  /** gap between each value. */
+  @Input() step = 1;
 
-  // Min value.
-  @Input()
-  min = 1;
-
-  // Max value.
-  @Input()
-  max = 1000;
-
-  // Step
-  @Input()
-  step = 1;
-
-  // Range to search
+  /** Range to search */
   range: Array<number> = null;
-
-  // True if route have aggregation query param.
+  /** True if route have aggregation query param. */
   hasQueryParam = false;
 
-  // Subscription to search service.
+  /** Subscription to search service. */
   private _searchServiceSubscription: Subscription;
 
+  // CONSTRUCTOR & HOOKS ======================================================
   /**
    * Constructor.
-   *
    * @param _recordSearchService Record search service.
    */
   constructor(private _recordSearchService: RecordSearchService) {}
 
   /**
-   * Component initialization.
-   *
-   * Subscribe to route changes for getting aggregation query parameter.
+   * OnInit hook
+   *   Subscribe to route changes for getting aggregation query parameter.
    */
   ngOnInit() {
     this.range = [this.min, this.max];
-
-    this._searchServiceSubscription = this._recordSearchService.aggregationsFilters.subscribe((filters: any) => {
-      if (!filters) {
-        return;
-      }
-
-      let filter = filters.find((element: any) => element.key === this.key);
-
-      if (filter) {
-        filter = filter.values[0].split('--').map((item: string) => {
-          return +item;
+    this._searchServiceSubscription = this._recordSearchService
+        .aggregationsFilters
+        .subscribe((filters: any) => {
+          if (!filters) {
+            return;
+          }
+          let filter = filters.find((element: any) => element.key === this.key);
+          if (filter) {
+            filter = filter.values[0].split('--').map((item: string) => +item);
+            this.hasQueryParam = true;
+            this.range = filter;
+          } else {
+            this.range = [this.min, this.max];
+          }
         });
-
-        this.hasQueryParam = true;
-        this.range = filter;
-      } else {
-        this.range = [this.min, this.max];
-      }
-    });
   }
 
   /**
-   * Component destruction.
-   *
-   * Unsubsribes from search service.
+   * OnDestroy hook
+   *   Unsubscribes from search service.
    */
   ngOnDestroy() {
     this._searchServiceSubscription.unsubscribe();
   }
 
-  /**
-   * Update aggregation filter.
-   */
+  // COMPONENT FUNCTIONS ======================================================
+  /** Update aggregation filter. */
   updateFilter() {
     if (!this.range[0] || this.range[0] < this.min) { this.range[0] = this.min; }
     if (!this.range[1] || this.range[1] > this.max) { this.range[1] = this.max; }
-
     this._recordSearchService.updateAggregationFilter(this.key, [
       `${this.range[0]}--${this.range[1]}`,
     ]);
   }
 
-  /**
-   * Clear aggregation filter.
-   */
+  /** Clear aggregation filter. */
   clearFilter() {
     this._recordSearchService.updateAggregationFilter(this.key, []);
   }

--- a/projects/rero/ng-core/src/lib/record/search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.component.html
@@ -43,16 +43,15 @@
     </ng-container>
     <ng-template #results>
       <div class="row align-items-start my-3">
-        <div class="col-sm-3 mb-3 mb-sm-0" *ngIf="showSearchInput">
-          <ng-core-search-input
-            [placeholder]="'search' | translate | ucfirst"
-            [searchText]="q"
-            [displayLabel]="false"
-            (search)="searchByQuery($event)"
-            [focus]="true"
-          >
-          </ng-core-search-input>
-        </div>
+        <ng-core-search-input
+          *ngIf="showSearchInput"
+          class="col-sm-3 mb-3 mb-sm-0"
+          [placeholder]="'search' | translate | ucfirst"
+          [searchText]="q"
+          [displayLabel]="false"
+          (search)="searchByQuery($event)"
+          [focus]="true"
+        ></ng-core-search-input>
         <div *ngIf="resultsText$ | async as resultsText" class="col-6 col-sm-3">
           <strong>{{ resultsText }}</strong>
         </div>
@@ -111,7 +110,7 @@
           [searchFilters]="searchFilters"
           >
         </ng-core-list-filters>
-
+        <ng-content select="[top-search-result]"></ng-content>
         <div *ngIf="(aggregations && aggregations.length) || searchFields.length > 0  || searchFilters.length > 0"
             class="col-sm-12 col-md-5 col-lg-3 order-2 order-md-1">
           <div *ngIf="searchFields.length > 0 && q"
@@ -191,8 +190,10 @@
             </div>
           </ng-container>
           <ng-container *ngIf="!showEmptySearchMessage || q">
+            <ng-content select="[top-facets]"></ng-content>
             <div *ngFor="let item of aggregations">
               <ng-core-record-search-aggregation
+                *ngIf="!aggregationsToHide.includes(item.key)"
                 [aggregation]="item"
                 [aggregationsFilters]="aggregationsFilters"
                 (aggregationClicked)="loadAggregationBuckets($event)"
@@ -206,6 +207,7 @@
             <i class="fa fa-info-circle"></i>
             {{ 'Enter a query to get results.' | translate }}
           </div>
+          <ng-content select="[top-result]"></ng-content>
           <ul class="list-group list-group-flush">
             <li class="list-group-item px-0 py-4" *ngFor="let record of records">
               <ng-core-record-search-result
@@ -237,9 +239,11 @@
             lastText="&raquo;"
           >
           </pagination>
+          <ng-content select="[footer-result]"></ng-content>
           <ng-content></ng-content>
         </div>
       </div>
+      <ng-content select="[footer-search-result]"></ng-content>
     </ng-template>
   </div>
 </ng-template>

--- a/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
@@ -89,9 +89,10 @@ export class RecordSearchService {
    * Stores selected values for an aggregation or removes it if values are empty.
    * @param term Term (aggregation key)
    * @param values Selected values
+   * @param bucket The complete ElasticSearch affected bucket configuration
    */
   updateAggregationFilter(term: string, values: string[], bucket: any = null) {
-    if (this._aggregationsFilters === null) {
+     if (this._aggregationsFilters === null) {
       this._aggregationsFilters = [];
     }
 
@@ -116,16 +117,16 @@ export class RecordSearchService {
         this._aggregationsFilters.push({ key: term, values: [...values] });
       }
     }
-
     this._aggregationsFiltersSubject.next(cloneDeep(this._aggregationsFilters));
   }
 
   /**
    * Remove a filter from the current aggregations filters.
-   * @param key filter name
-   * @param value filter value
+   * @param key - the filter name
+   * @param value - the filter value
+   * @param emit - is the `_aggregationsFiltersSubject` should be emitted
    */
-  removeFilter(key, value, emit = false) {
+  removeFilter(key: string, value: string, emit: boolean = false): void {
     const filter = this._aggregationsFilters.find(item => item.key === key);
     if (filter) {
       filter.values = filter.values.filter(item => item !== value);
@@ -141,18 +142,18 @@ export class RecordSearchService {
 
   /**
    * Check if a given filter exist in the current aggregations filters.
-   * @param key filter name
-   * @param value filter value
-   * @returns true if exists
+   * @param key - the filter name
+   * @param value - the filter value
+   * @returns `true` if exists
    */
-   hasFilter(key, value): boolean {
+   hasFilter(key: string, value: string): boolean {
     const filter = this._aggregationsFilters.find((a) => a.key === key);
-    return !!(filter && filter.values.some((v) => v === value));
+    return !!(filter && filter.values.some(v => v === value));
   }
 
   /**
    * Remove the parent filters of a given bucket.
-   * @param bucket elasticseach bucket
+   * @param bucket - The ElasticSearch bucket
    */
   removeParentFilters(bucket) {
     if (bucket.parent) {
@@ -163,7 +164,7 @@ export class RecordSearchService {
 
   /**
    * Removes children filters of a given bucket.
-   * @param bucket elatic bucket
+   * @param bucket - The ElasticSearch bucket
    */
   removeChildrenFilters(bucket) {
     for (const k of Object.keys(bucket).filter(key => bucket[key].buckets)) {
@@ -177,8 +178,8 @@ export class RecordSearchService {
 
   /**
    * Check if a children filter of a given bucket exists
-   * @param bucket elasticsearch bucket
-   * @returns true if has childre with a corresponding filter
+   * @param bucket - The ElasticSearch bucket
+   * @returns `true` if the bucket has children with a corresponding filter
    */
   hasChildrenFilter(bucket) {
     for (const k of Object.keys(bucket).filter(key => typeof bucket[key] === 'object' && bucket[key].buckets)) {


### PR DESCRIPTION
* Adds some areas into the default `record-search` component (used to
  render a search result) to allow content injection :
  top-search-result, top-result, top-facets, bottom-result,
  bottom-search-result.
* Add option to always hide a facet : In some case, we need to request
  to backend about a facet, but this facet should never be displayed
  by search components (other component can use content-injection to
  display them).

Co-authored-by: Renaud Michotte <renaud.michotte@gmail.com>

# How to test 

![image](https://user-images.githubusercontent.com/10031585/201529768-655bb9ac-2ecd-4454-baad-c82c5c1cf654.png)

