### PR TITLE
results: allow default aggregation using the search input

### DIFF
--- a/projects/ng-core-tester/src/app/routes/documents-route.ts
+++ b/projects/ng-core-tester/src/app/routes/documents-route.ts
@@ -65,6 +65,10 @@ export class DocumentsRoute implements RouteInterface {
             editorSettings: {
               longMode: true
             },
+            defaultSearchInputFilters: [{
+              'key': 'organisation',
+              'values': [1]
+            }],
             aggregationsOrder: [
               'document_type',
               'author',


### PR DESCRIPTION
Allow to define default aggregations to always add when user use the result page serach input form.

Co-Authored-by: Renaud Michotte <renaud.michotte@gmail.com>

