### PR TITLE
formly: add filter on remote typeahead

### DIFF
--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -32,7 +32,9 @@
     "email",
     "date_time",
     "password",
-    "array_with_multicheckbox"
+    "array_with_multicheckbox",
+    "remoteTypeaheadWithoutFilters",
+    "remoteTypeaheadWithFilters"
   ],
   "required": [
     "required"
@@ -894,6 +896,51 @@
                 "value": "checkbox4"
               }
             ]
+          }
+        }
+      }
+    },
+    "remoteTypeaheadWithFilters": {
+      "title": "Remote typeahead with filters",
+      "type": "string",
+      "widget": {
+        "formlyConfig": {
+          "type": "remoteTypeahead",
+          "templateOptions": {
+            "remoteTypeahead": {
+              "enableGroupField": true,
+              "filters": {
+                "default": "value2",
+                "options": [
+                  {
+                    "label": "Value 1",
+                    "value": "value1"
+                  },
+                  {
+                    "label": "Value 2",
+                    "value": "value2"
+                  },
+                  {
+                    "label": "Value 3",
+                    "value": "value3"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "remoteTypeaheadWithoutFilters": {
+      "title": "Remote typeahead without filters",
+      "type": "string",
+      "widget": {
+        "formlyConfig": {
+          "type": "remoteTypeahead",
+          "templateOptions": {
+            "remoteTypeahead": {
+              "enableGroupField": true
+            }
           }
         }
       }

--- a/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/remote-typeahead/remote-typeahead.component.html
@@ -1,6 +1,6 @@
 <!--
   RERO angular core
-  Copyright (C) 2020 RERO
+  Copyright (C) 2020-2023 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -18,6 +18,17 @@
 <!-- input field: empty ref -->
 <ng-container *ngIf="formControl">
   <div *ngIf="!formControl.value; else metadataTemplate" class="input-group">
+    <ng-container *ngIf="filters?.options">
+      <div class="input-group-prepend">
+        <select class="form-control input-group-text" [class]="filters?.itemCssClass" (change)="changeFilter($event.target.value)">
+          <option
+            *ngFor="let option of filters.options"
+            [value]="option.value"
+            [selected]="filters?.default === option.value"
+          >{{ option.label | translate }}</option>
+        </select>
+      </div>
+    </ng-container>
     <input class="form-control" [(ngModel)]="search" autocomplete="off" [typeaheadAsync]="true"
       [typeahead]="suggestions$" (typeaheadLoading)="changeTypeaheadLoading($event)"
       (typeaheadOnSelect)="typeaheadOnSelect($event)" [typeaheadWaitMs]="300" [typeaheadMinLength]="2"


### PR DESCRIPTION
It is possible to configure filters directly in the jsonschema with a new entry "filters" in templateOptions.

### Display

<img width="1298" alt="remote-filter" src="https://user-images.githubusercontent.com/48578/219299369-8b569a99-aaff-4dd4-869f-099772a73569.png">
