### PR TITLE
formly: add a set default value

### DIFF
--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -34,7 +34,8 @@
     "password",
     "array_with_multicheckbox",
     "remoteTypeaheadWithoutFilters",
-    "remoteTypeaheadWithFilters"
+    "remoteTypeaheadWithFilters",
+    "input_with_default_value"
   ],
   "required": [
     "required"
@@ -941,6 +942,19 @@
             "remoteTypeahead": {
               "enableGroupField": true
             }
+          }
+        }
+      }
+    },
+    "input_with_default_value": {
+      "title": "Input with default value (jsonschema: defaultValueExpression)",
+      "type": "string",
+      "description": "Calculates a default value for the field",
+      "minLength": 1,
+      "widget": {
+        "formlyConfig": {
+          "templateOptions": {
+            "defaultValueExpression": "(Math.random() + 1).toString(36).substring(2)"
           }
         }
       }

--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -78,6 +78,12 @@ export class NgCoreFormlyExtension {
         }
       });
     }
+
+    field.options.fieldChanges.subscribe((changes) => {
+      if (changes.type === 'hidden' && changes.value === false) {
+        this._setDefaultValue(field);
+      }
+    });
   }
 
   /**
@@ -396,6 +402,22 @@ export class NgCoreFormlyExtension {
           },
         },
       };
+    }
+  }
+
+  /**
+   * Assigns the default value on the field if it has
+   * a defaultValueExpression definition in the jsonschema.
+   * @param field - FormlyFieldConfig
+   */
+  private _setDefaultValue(field: FormlyFieldConfig): void {
+    if (field.templateOptions?.defaultValueExpression) {
+      const key = String(field.key);
+      if (!(key in field.model && field.model[key] !== null)) {
+        const expression = field.templateOptions.defaultValueExpression;
+        const expressionFn = Function('expression', `return ${expression};`);
+        field.formControl.setValue(expressionFn());
+      }
     }
   }
 }


### PR DESCRIPTION
In the jsonschema, it is possible to define the defaultValueExpression function to assign a default value to the field.
