### PR TITLE
search: fix number facets behavior

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search/aggregation/buckets/buckets.component.ts
@@ -127,11 +127,11 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
   // COMPONENT F£UNCTIONS =====================================================
   /**
    * Check if a value is present in selected filters.
-   * @param value - string: filter value
+   * @param value: filter value (could be string, number, ...)
    * @return `true` if value is present in the aggregation filters, `false` otherwise.
    */
-  isSelected(value: string): boolean {
-    return this.aggregationFilters.includes(value);
+  isSelected(value: any): boolean {
+    return this.aggregationFilters.includes(value.toString());
   }
 
   /**
@@ -161,9 +161,9 @@ export class BucketsComponent implements OnInit, OnDestroy, OnChanges {
       this._recordSearchService.updateAggregationFilter(this.aggregationKey, [bucket.key], bucket);
     } else {
       const aggFilter = this.aggregationsFilters[index];
-      if (!aggFilter.values.includes(bucket.key)) {
+      if (!aggFilter.values.includes(bucket.key.toString())) {
         // Bucket value is not yet selected, we add value to selected values.
-        this.aggregationsFilters[index].values.push(bucket.key);
+        this.aggregationsFilters[index].values.push(bucket.key.toString());
         this._recordSearchService.updateAggregationFilter(
           this.aggregationKey,
           this.aggregationsFilters[index].values,

--- a/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
+++ b/projects/rero/ng-core/src/lib/record/search/record-search.service.ts
@@ -60,7 +60,7 @@ export class RecordSearchService {
    * @param bucket Bucket containing the value to remove
    */
   removeAggregationFilter(key: string, bucket: any) {
-    this.removeFilter(key, bucket.key);
+    this.removeFilter(key, bucket.key.toString());
     this.removeChildrenFilters(bucket);
     this.removeParentFilters(bucket);
     // Update selected aggregations filters


### PR DESCRIPTION
Behavior to know if a facet is selected or not are based on query string argument; the value of a query string argument is always a "string". But For an aggregation/facet with only numeric values, all checks failed because we compared "string" versus "number". To fix this, we add the ".toString()" (available for all native datatype) method into the
 required functions.
