### PR TITLE
files: add permissions

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
-  "newProjectRoot": "projects",
+  "defaultProject": "@rero/ng-core",
   "projects": {
     "@rero/ng-core": {
       "projectType": "library",
@@ -166,16 +166,6 @@
           }
         }
       }
-    }
-  },
-  "cli": {
-    "schematicCollections": [
-      "@ngx-formly/schematics"
-    ]
-  },
-  "schematics": {
-    "@ngx-formly/schematics:component": {
-      "styleext": "scss"
     }
   }
 }

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.html
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.html
@@ -46,6 +46,7 @@
       <i class="fa fa-pencil"></i>
       {{ 'Edit' | translate }}
     </a>
+
     <ng-container *ngIf="deleteStatus">
       <button id="detail-delete-button" class="btn btn-sm btn-outline-danger ml-1" [title]="'Delete'|translate" (click)="deleteRecord(record)"
         *ngIf="deleteStatus.can; else deleteMessageLink">

--- a/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
+++ b/projects/rero/ng-core/src/lib/record/detail/detail.component.ts
@@ -165,7 +165,6 @@ export class DetailComponent implements OnInit, OnDestroy {
               this._location.back();
             }
           });
-
           this._recordUiService.canDeleteRecord$(this.record, this._type).subscribe(result => {
             this.deleteStatus = result;
           });

--- a/projects/rero/ng-core/src/lib/record/files/file/file.component.html
+++ b/projects/rero/ng-core/src/lib/record/files/file/file.component.html
@@ -1,0 +1,81 @@
+<!--
+  RERO angular core
+  Copyright (C) 2022 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-container *ngIf="file">
+  <div class="row">
+    <div class="col" [ngClass]="{ 'pl-5 text-muted': !file.is_head }">
+      <p class="m-0">
+        {{ file.key }}
+        <a href="#" class="ml-2" (click)="$event.preventDefault(); file.showInfo = !file.showInfo">
+          <i class="fa fa-info-circle"></i>
+        </a>
+        <a
+          href="#"
+          class="ml-2"
+          (click)="$event.preventDefault(); file.showChildren = !file.showChildren"
+          *ngIf="hasChildren"
+        >
+          <i class="fa fa-history"></i>
+        </a>
+      </p>
+    </div>
+    <div class="col text-right">
+      <button *ngIf="canUpdateMetadata.can" class="btn btn-sm btn-outline-primary" (click)="editMetadata()">
+        <i class="fa fa-pencil mr-1"></i>{{ 'Edit' | translate }}
+      </button>
+
+      <button *ngIf="canUpdate.can" class="btn btn-sm btn-outline-primary ml-1" (click)="manage()">
+        <i class="fa fa-upload mr-1"></i>{{ 'New version' | translate }}
+      </button>
+
+      <a [href]="file.url" target="_blank" class="btn btn-sm btn-outline-primary ml-1" download>
+        <i class="fa fa-download mr-1"></i>{{ 'Download' | translate }}
+      </a>
+
+      <button *ngIf="canDelete.can" class="btn btn-sm btn-outline-danger ml-1" (click)="delete()">
+        <i class="fa fa-trash mr-1"></i>{{ 'Delete' | translate }}
+      </button>
+    </div>
+  </div>
+  <div class="row mt-2" *ngIf="file.showInfo">
+    <div class="col" *ngIf="file.is_head">
+      <dl class="row mt-2 mb-0">
+        <ng-container *ngFor="let item of file.metadata | keyvalue">
+          <ng-container *ngIf="!infoExcludedFields.includes(item.key) && item.value">
+            <dt class="col-lg-4">{{ item.key | translate }}</dt>
+            <dd class="col-lg-8">{{ item.value | translate }}</dd>
+          </ng-container>
+        </ng-container>
+      </dl>
+    </div>
+    <div class="col" [ngClass]="{ 'pl-5 text-muted': !file.is_head }">
+      <dl class="row mt-2 mb-0">
+        <dt class="col-lg-4" translate>Size</dt>
+        <dd class="col-lg-8">{{ file.size | filesize }}</dd>
+
+        <dt class="col-lg-4" translate>Mime type</dt>
+        <dd class="col-lg-8">{{ file.mimetype }}</dd>
+
+        <dt class="col-lg-4" translate>Checksum</dt>
+        <dd class="col-lg-8">{{ file.checksum }}</dd>
+
+        <dt class="col-lg-4" translate>Modified at</dt>
+        <dd class="col-lg-8">{{ file.updated | dateTranslate : 'medium' }}</dd>
+      </dl>
+    </div>
+  </div>
+</ng-container>

--- a/projects/rero/ng-core/src/lib/record/files/file/file.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/files/file/file.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FileComponent } from './file.component';
+import { RecordUiService } from '../../record-ui.service';
+import { TranslateModule } from '@ngx-translate/core';
+
+const recordUiServiceSpy = jasmine.createSpyObj('RecordUiService', ['getResourceConfig']);
+recordUiServiceSpy.getResourceConfig.and.returnValue({ key: 'documents', files: {} });
+describe('FileComponent', () => {
+  let component: FileComponent;
+  let fixture: ComponentFixture<FileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FileComponent],
+      imports: [TranslateModule.forRoot()],
+      providers: [{ provide: RecordUiService, useValue: recordUiServiceSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileComponent);
+    component = fixture.componentInstance;
+    component.type = 'documents';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/rero/ng-core/src/lib/record/files/file/file.component.ts
+++ b/projects/rero/ng-core/src/lib/record/files/file/file.component.ts
@@ -1,0 +1,130 @@
+/*
+ * RERO angular core
+ * Copyright (C) 2023 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { RecordUiService } from '../../record-ui.service';
+import { Subscription, of } from 'rxjs';
+import { ActionStatus } from '../../action-status';
+
+@Component({
+  selector: 'ng-core-record-file',
+  templateUrl: './file.component.html',
+})
+export class FileComponent implements OnInit, OnDestroy {
+  // record data
+  @Input() record: any;
+
+  // record file data
+  @Input() file: any;
+
+  // record type
+  @Input() type: any;
+
+  // true if the file has old versions
+  @Input() hasChildren: boolean;
+
+  // list of fields to not display
+  @Input() infoExcludedFields: Array<string> = [];
+
+  // event emitter when the delete button is clicked
+  @Output() deleteFile: EventEmitter<void> = new EventEmitter();
+
+  // event emitter when the edit metadata button is clicked
+  @Output() manageFile: EventEmitter<void> = new EventEmitter();
+
+  // event emitter when edit button is clicked
+  @Output() editMetadataFile: EventEmitter<void> = new EventEmitter();
+
+  // permissions
+  canUpdateMetadata: ActionStatus;
+  canUpdate: ActionStatus;
+  canDelete: ActionStatus;
+
+  // subscriptions to observables
+  private _subscriptions: Subscription = new Subscription();
+
+  /**
+   * Constructor.
+   *
+   * @param _recordUiService RecordUiService.
+   */
+  constructor(private _recordUiService: RecordUiService) {}
+
+  /**
+   * hook OnInit
+   */
+  ngOnInit(): void {
+    this.loadPermission();
+  }
+
+  /**
+   * Loads the permissions.
+   */
+  loadPermission() {
+    const config = this._recordUiService.getResourceConfig(this.type);
+    let obs$ = config.files.canUpdate
+      ? config.files.canUpdate(this.record, this.file)
+      : of({ can: false, message: '' });
+    this._subscriptions.add(
+      obs$.subscribe((result: ActionStatus) => {
+        this.canUpdate = result;
+      })
+    );
+    obs$ = config.files.canDelete ? config.files.canDelete(this.record, this.file) : of({ can: false, message: '' });
+    this._subscriptions.add(
+      obs$.subscribe((result: ActionStatus) => {
+        this.canDelete = result;
+      })
+    );
+    obs$ = config.files.canUpdate
+      ? config.files.canUpdateMetadata(this.record, this.file)
+      : of({ can: false, message: '' });
+    this._subscriptions.add(
+      obs$.subscribe((result: ActionStatus) => {
+        this.canUpdateMetadata = result;
+      })
+    );
+  }
+
+  /**
+   * Component destruction.
+   */
+  ngOnDestroy(): void {
+    this._subscriptions.unsubscribe();
+  }
+
+  /**
+   * Delete the file.
+   */
+  delete() {
+    this.deleteFile.emit();
+  }
+
+  /**
+   * Edit the files.
+   */
+  manage() {
+    this.manageFile.emit();
+  }
+
+  /**
+   * Edit the metadata.
+   */
+  editMetadata() {
+    this.editMetadataFile.emit();
+  }
+}

--- a/projects/rero/ng-core/src/lib/record/files/files.component.html
+++ b/projects/rero/ng-core/src/lib/record/files/files.component.html
@@ -1,16 +1,16 @@
 <!--
   RERO angular core
   Copyright (C) 2020 RERO
- 
+
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
   the Free Software Foundation, version 3 of the License.
- 
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
   GNU Affero General Public License for more details.
- 
+
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
@@ -22,74 +22,28 @@
     <ul class="list-group list-group-flush">
       <ng-container *ngFor="let file of files">
         <li class="list-group-item" *ngIf="showItem(file)">
-          <div class="row">
-            <div class="col-sm-6" [ngClass]="{ 'pl-5 text-muted': !file.is_head }">
-              <p class="m-0">
-                {{ file.key }}
-                <a href="#" class="ml-2" (click)="$event.preventDefault(); file.showInfo = !file.showInfo">
-                  <i class="fa fa-info-circle"></i>
-                </a>
-                <a href="#" class="ml-2" (click)="$event.preventDefault(); file.showChildren = !file.showChildren"
-                  *ngIf="hasChildren(file)">
-                  <i class="fa fa-history"></i>
-                </a>
-              </p>
-            </div>
-            <div class="col-sm-6 text-right">
-              <button class="btn btn-sm btn-outline-primary" (click)="editMetadata(file)"
-                *ngIf="file.is_head && file.metadata && updateMetadata.can">
-                <i class="fa fa-pencil mr-1"></i>{{ 'Edit' | translate }}
-              </button>
-              <button class="btn btn-sm btn-outline-primary ml-1" (click)="manageFile(file)" *ngIf="file.is_head">
-                <i class="fa fa-upload mr-1"></i>{{ 'New version' | translate }}
-              </button>
-              <a [href]="getFileUrl(file)" target="_blank" class="btn btn-sm btn-outline-primary ml-1" download>
-                <i class="fa fa-download mr-1"></i>{{ 'Download' | translate }}
-              </a>
-              <button class="btn btn-sm btn-outline-danger ml-1" (click)="delete(file)">
-                <i class="fa fa-trash mr-1"></i>{{ 'Delete' | translate }}
-              </button>
-            </div>
-          </div>
-          <div class="row mt-2" *ngIf="file.showInfo && !metadataForm.model">
-            <div class="col-lg-6" *ngIf="file.is_head">
-              <dl class="row mt-2 mb-0">
-                <ng-container *ngFor="let item of file.metadata | keyvalue">
-                  <ng-container *ngIf="!infoExcludedFields.includes(item.key) && item.value">
-                    <dt class="col-sm-4">{{ item.key | translate }}</dt>
-                    <dd class="col-sm-8">{{ item.value | translate }}</dd>
-                  </ng-container>
-                </ng-container>
-              </dl>
-            </div>
-            <div class="col-lg-6" [ngClass]="{ 'pl-5 text-muted': !file.is_head }">
-              <dl class="row mt-2 mb-0">
-                <dt class="col-sm-4" translate>Size</dt>
-                <dd class="col-sm-8">{{ file.size | filesize }}</dd>
-
-                <dt class="col-sm-4" translate>Mime type</dt>
-                <dd class="col-sm-8">{{ file.mimetype }}</dd>
-
-                <dt class="col-sm-4" translate>Checksum</dt>
-                <dd class="col-sm-8">{{ file.checksum }}</dd>
-
-                <dt class="col-sm-4" translate>Modified at</dt>
-                <dd class="col-sm-8">{{ file.updated | dateTranslate:'medium' }}</dd>
-              </dl>
-            </div>
-          </div>
+          <ng-core-record-file
+            [type]=type
+            [record]=record
+            [file]=file
+            [hasChildren]=hasChildren(file)
+            [infoExcludedFields]=infoExcludedFields
+            (deleteFile)=deleteFile(file)
+            (editMetadataFile)=editMetadataFile(file)
+            (manageFile)=manageFile(file)
+          ></ng-core-record-file>
         </li>
       </ng-container>
     </ul>
   </ng-container>
-  <ng-template #noFiles>
-  </ng-template>
+
   <div class="card-body" *ngIf="hasError || files.length === 0">
-    <div class="alert alert-info m-0" *ngIf="!hasError && files.length === 0" translate>No file found for this record.
+    <div class="alert alert-info m-0" *ngIf="!hasError && files.length === 0" translate>
+      No file found for this record.
     </div>
     <div class="alert alert-danger m-0" *ngIf="hasError" translate>An error occurred, files cannot be loaded.</div>
   </div>
-  <div class="card-footer text-center">
+  <div *ngIf=canAdd.can class="card-footer text-center">
     <button class="btn btn-sm btn-primary" (click)="manageFile(null)">
       <i class="fa fa-plus mr-1"></i>{{ 'Add a new file' | translate }}
     </button>
@@ -98,18 +52,18 @@
 
 <ng-template #formModal>
   <div class="modal-header">
-    <h4 class="modal-title pull-left">{{ currentFile ? currentFile.key : 'Add a new file' | translate }}</h4>
+    <h4 class="modal-title pull-left">{{ currentFile ? currentFile.key : ('Add a new file' | translate) }}</h4>
     <button type="button" class="close pull-right" aria-label="Close" (click)="formModalRef.hide()">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
   <div class="modal-body">
     <div class="form-group">
-      <input #file type="file" id="file" (change)="handleFileInput($event.target.files)">
+      <input #file type="file" id="file" (change)="handleFileInput($event.target.files)" />
     </div>
     <div class="form-group" *ngIf="!currentFile && filesToUpload">
       <label for="file-key" translate>File name</label>
-      <input type="text" id="file-key" class="form-control" [(ngModel)]="fileKey">
+      <input type="text" id="file-key" class="form-control" [(ngModel)]="fileKey" />
     </div>
     <div>
       <ng-container *ngIf="filesToUpload && filesToUpload.length > 0">
@@ -128,7 +82,7 @@
   <ng-container *ngIf="metadataForm.model">
     <div class="modal-header">
       <h4 class="modal-title pull-left">{{ metadataForm.model.key }}</h4>
-      <button type="button" class="close pull-right" aria-label="Close" (click)="hideForm();">
+      <button type="button" class="close pull-right" aria-label="Close" (click)="hideForm()">
         <span aria-hidden="true">&times;</span>
       </button>
     </div>

--- a/projects/rero/ng-core/src/lib/record/files/files.component.ts
+++ b/projects/rero/ng-core/src/lib/record/files/files.component.ts
@@ -90,11 +90,11 @@ export class RecordFilesComponent implements OnDestroy, OnInit {
     'checksum',
     'file_id',
     'size',
-    'version_id',
+    'version_id'
   ];
 
   // Observable resolving if files metadata can be updated.
-  updateMetadata: ActionStatus = { can: false, message: '' };
+  canAdd: ActionStatus = { can: false, message: '' };
 
   // Configuration for record type.
   private _config: any;
@@ -156,16 +156,6 @@ export class RecordFilesComponent implements OnDestroy, OnInit {
       );
     }
 
-    // Check if metadata can be updated.
-    const canUpdateMetadata$ = this._config.files.canUpdateMetadata
-      ? this._config.files.canUpdateMetadata()
-      : of({ can: false, message: '' });
-    this._subscriptions.add(
-      canUpdateMetadata$.subscribe((result: ActionStatus) => {
-        this.updateMetadata = result;
-      })
-    );
-
     this._spinner.show();
 
     // Load files
@@ -226,7 +216,7 @@ export class RecordFilesComponent implements OnDestroy, OnInit {
    *
    * @param file File object to delete
    */
-  delete(file: RecordFile) {
+  deleteFile(file: RecordFile) {
     this._dialogService
       .show({
         ignoreBackdropClick: true,
@@ -419,7 +409,7 @@ export class RecordFilesComponent implements OnDestroy, OnInit {
    * @param file File object.
    * @returns void
    */
-  editMetadata(file: RecordFile): void {
+  editMetadataFile(file: RecordFile): void {
     if (!file.metadata) {
       return;
     }
@@ -487,6 +477,7 @@ export class RecordFilesComponent implements OnDestroy, OnInit {
         files = files.map((item: RecordFile) => {
           // By default, show info about the file.
           item.showInfo = true;
+          item.url = this.getFileUrl(item);
 
           // By default, hide other versions of the file.
           item.showChildren = false;
@@ -507,7 +498,16 @@ export class RecordFilesComponent implements OnDestroy, OnInit {
         }
 
         this.files = files;
-      }),
+       }),
+       tap(() => {
+          // Check if a file can be added.
+          const canAdd$ = this._config.files.canAdd
+            ? this._config.files.canAdd()
+            : of({ can: false, message: '' });
+          this._subscriptions.add(
+            canAdd$.subscribe((result: ActionStatus) => this.canAdd = result)
+          );
+       }),
       catchError(() => {
         this.hasError = true;
         return of([]);

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -75,6 +75,7 @@ import { RecordSearchComponent } from './search/record-search.component';
 import { JsonComponent } from './search/result/item/json.component';
 import { RecordSearchResultComponent } from './search/result/record-search-result.component';
 import { RecordSearchResultDirective } from './search/result/record-search-result.directive';
+import { FileComponent } from './files/file/file.component';
 
 @NgModule({
     declarations: [
@@ -118,7 +119,8 @@ import { RecordSearchResultDirective } from './search/result/record-search-resul
         BucketNamePipe,
         DateTimepickerTypeComponent,
         PasswordGeneratorTypeComponent,
-        MulticheckboxComponent
+        MulticheckboxComponent,
+        FileComponent
     ],
     imports: [
         // NOTE : BrowserAnimationModule **should** be include in application core module.

--- a/projects/rero/ng-core/src/lib/record/record.ts
+++ b/projects/rero/ng-core/src/lib/record/record.ts
@@ -32,6 +32,7 @@ export class SearchResult {
 export interface File {
   updated: string;
   size: string;
+  url?: string;
   mimetype: string;
   version_id: string;
   is_head: boolean;


### PR DESCRIPTION
* Fixes broken `ng` command such as `ng c`.
* Adds permissions support to the file component to hide action buttons.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
