### PR TITLE
fix(editor): datepicker should be smaller instead of taking the whole width of the screen

### DIFF
--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -1227,7 +1227,6 @@
           "type": "dateTimePicker",
           "props": {
             "dataType": "string",
-            "styleClass": "ui:w-full",
             "showTime": true,
             "validation": {
               "messages": {

--- a/projects/rero/ng-core/src/lib/prime-ng-core-module.ts
+++ b/projects/rero/ng-core/src/lib/prime-ng-core-module.ts
@@ -47,6 +47,7 @@ import { TieredMenuModule } from 'primeng/tieredmenu';
 import { ToastModule } from 'primeng/toast';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
+import { FluidModule } from 'primeng/fluid'
 
 @NgModule({
   providers: [
@@ -66,6 +67,7 @@ import { TooltipModule } from 'primeng/tooltip';
     DividerModule,
     DynamicDialogModule,
     FieldsetModule,
+    FluidModule,
     InputGroupAddonModule,
     InputGroupModule,
     InputNumberModule,

--- a/projects/rero/ng-core/src/lib/record/editor/formly/primeng/date-picker/date-picker.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/formly/primeng/date-picker/date-picker.spec.ts
@@ -49,9 +49,11 @@ describe('DatePickerComponent', () => {
         dateFormat: 'yy-mm-dd',
         disabled: false,
         firstDayOfWeek: 0,
+        fluid: true,
         inline: false,
         numberOfMonths: 1,
         outputDateFormat: 'yyyy-MM-dd',
+        panelStyleClass: '',
         required: false,
         selectionMode: 'single',
         showButtonBar: false,
@@ -61,7 +63,7 @@ describe('DatePickerComponent', () => {
         stepHour: 1,
         stepMinute: 1,
         stepSecond: 1,
-        styleClass: 'w-full',
+        styleClass: '',
         todayButtonStyleClass: 'p-button-text',
         view: 'date'
       }

--- a/projects/rero/ng-core/src/lib/record/editor/formly/primeng/date-picker/date-picker.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/formly/primeng/date-picker/date-picker.ts
@@ -30,6 +30,7 @@ export interface IDateTimePickerProps extends FormlyFieldProps {
   disabledDates?: Date[];
   disabledDays?: number[];
   firstDayOfWeek?: number;
+  fluid: boolean;
   hourFormat?: string;
   inline: boolean;
   inputStyleClass?: string;
@@ -37,6 +38,7 @@ export interface IDateTimePickerProps extends FormlyFieldProps {
   maxDate?: Date;
   minDate?: Date;
   numberOfMonths: number;
+  panelStyleClass: string;
   readonlyInput?: boolean;
   selectionMode: 'multiple' | 'range' | 'single';
   showButtonBar: boolean;
@@ -46,7 +48,7 @@ export interface IDateTimePickerProps extends FormlyFieldProps {
   stepHour: number;
   stepMinute: number;
   stepSecond: number;
-  styleClass: string;
+  styleClass?: string;
   todayButtonStyleClass: string;
   view?: 'date' | 'month' | 'year';
 }
@@ -65,12 +67,14 @@ export interface IDateTimePickerProps extends FormlyFieldProps {
       [disabledDates]="disabledDates"
       [disabledDays]="props.disabledDays"
       [firstDayOfWeek]="props.firstDayOfWeek"
+      [fluid]="props.fluid"
       [hourFormat]="props.hourFormat"
       [inline]="props.inline"
       [inputStyleClass]="props.inputStyleClass"
       [maxDate]="maxDate"
       [minDate]="minDate"
       [numberOfMonths]="props.numberOfMonths"
+      [panelStyleClass]="props.panelStyleClass"
       [placeholder]="props.placeholder"
       [readonlyInput]="props.readonlyInput || props.selectionMode !== 'single'"
       [required]="props.required"
@@ -102,9 +106,11 @@ export class DatePickerComponent extends FieldType<FormlyFieldConfig<IDateTimePi
       dateFormat: 'yy-mm-dd',
       disabled: false,
       firstDayOfWeek: 0,
+      fluid: true,
       inline: false,
       numberOfMonths: 1,
       outputDateFormat: 'yyyy-MM-dd',
+      panelStyleClass: 'core:!min-w-0',
       placeholder: 'Select…',
       required: false,
       selectionMode: 'single',
@@ -115,7 +121,6 @@ export class DatePickerComponent extends FieldType<FormlyFieldConfig<IDateTimePi
       stepHour: 1,
       stepMinute: 1,
       stepSecond: 1,
-      styleClass: 'core:w-full',
       todayButtonStyleClass: 'p-button-text',
       view: 'date'
     },


### PR DESCRIPTION
- Uses fluid instead of full width for the datepicker.
- Removes the minimum width on the date picker panel.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
