### PR TITLE
feat(editor): sort label by language on add a field

### DIFF
--- a/projects/ng-core-tester/src/assets/i18n/de.json
+++ b/projects/ng-core-tester/src/assets/i18n/de.json
@@ -1,4 +1,5 @@
 {
+  "Array": "Array",
   "search": "Eine Ressource suchen",
   "location": "Standort",
   "created year": "Erstellungsjahr",
@@ -53,5 +54,6 @@
   "Checkbox 4": "Checkbox 4",
   "Radio button 1": "Radio Knopf 1",
   "Radio button 2": "Radio Knopf 2",
-  "Radio button 3": "Radio Knopf 3"
+  "Radio button 3": "Radio Knopf 3",
+  "Password": "Passwort"
 }

--- a/projects/ng-core-tester/src/assets/i18n/fr.json
+++ b/projects/ng-core-tester/src/assets/i18n/fr.json
@@ -1,4 +1,5 @@
 {
+  "Array": "Tableau",
   "Always hidden": "Toujours caché",
   "Hidden": "Caché",
   "Default hidden": "Caché par défaut",
@@ -69,5 +70,6 @@
   "Checkbox 4": "Case à cocher 4",
   "Radio button 1": "Bouton radio 1",
   "Radio button 2": "Bouton radio 2",
-  "Radio button 3": "Bouton radio 3"
+  "Radio button 3": "Bouton radio 3",
+  "Password": "Mot de passe"
 }

--- a/projects/ng-core-tester/src/assets/i18n/it.json
+++ b/projects/ng-core-tester/src/assets/i18n/it.json
@@ -1,4 +1,5 @@
 {
+  "Array": "Tabella",
   "search": "Ricerca di una risorsa",
   "location": "Localizzazione",
   "created year": "Anno di creazione",
@@ -53,5 +54,6 @@
   "Checkbox 4": "Casella 4",
   "Radio button 1": "Pulsante radio 1",
   "Radio button 2": "Pulsante radio 2",
-  "Radio button 3": "Pulsante radio 3"
+  "Radio button 3": "Pulsante radio 3",
+  "Password": "Password"
 }

--- a/projects/rero/ng-core/src/lib/record/editor/editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/editor.component.html
@@ -78,7 +78,7 @@
       <div class="core:grow core:flex core:gap-2">
         <!-- ngx-formly -->
           <formly-form
-            class="core:grow core:**:scroll-mt-18"
+            class="core:grow"
             [model]="model"
             [fields]="fields"
             [options]="options"

--- a/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.html
@@ -16,7 +16,13 @@
 -->
 <div [class]="props.containerCssClass">
   @for (f of field.fieldGroup; track f.id) {
-    <div [hidden]="f.hide" [class]="f.props.itemCssClass" [id]="'field-' + f.id">
+    <!-- the core:scroll-mt-18 class is added for sticky -->
+    <div
+      [hidden]="f.hide"
+      [class]="f.props.itemCssClass"
+      [ngClass]="{'core:scroll-mt-18': (props.isRoot && props.editorConfig?.longMode)}"
+      [id]="'field-' + f.id"
+    >
       <formly-field [field]="f" />
     </div>
   }

--- a/projects/rero/ng-core/src/lib/record/editor/widgets/add-field-editor/add-field-editor.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/widgets/add-field-editor/add-field-editor.component.html
@@ -24,21 +24,21 @@
       [suggestions]="suggestions"
       (completeMethod)="search($event)"
       (onSelect)="onSelect($event)"
-      [disabled]="items.length < 1"
+      [disabled]="items().length < 1"
       scrollHeight="400px"
       appendTo="body"
     />
   </div>
 
-@if(essentialsOptions?.length > 0) {
+@if(essentialsOptions()?.length > 0) {
   <p-listbox
-    [options]="essentialsOptions"
+    [options]="essentialsOptions()"
     scrollHeight=""
     styleClass="core:mt-2"
     (onChange)="onAddField($event)"
   >
     <ng-template #item let-item>
-      {{ item.label | async }}
+      {{ item.props.label }}
     </ng-template>
   </p-listbox>
 }


### PR DESCRIPTION
The list of fields in "Add a field" for long-form editors should be sorted alphabetically (in the current language). The same applies to the list of essential fields.

* Fixes the scrolling on the editor.
* Refines search function for phrase selection.