### PR TITLE
fix(search): allow launching a search also with numpad "Enter"

### DIFF
--- a/projects/rero/ng-core/src/lib/record/search-autocomplete/search-autocomplete.component.ts
+++ b/projects/rero/ng-core/src/lib/record/search-autocomplete/search-autocomplete.component.ts
@@ -130,7 +130,7 @@ export class SearchAutocompleteComponent implements AfterViewInit{
   }
 
   search(event: KeyboardEvent) {
-    if(event?.code === 'Enter') {
+    if(event?.key === 'Enter') {
       this.onSearch.emit(this.currentValue);
     }
   }


### PR DESCRIPTION
Replace `event.code:'Enter'` by `event.key:'Enter'` so that it includes NumpadEnter.
Close https://github.com/rero/rero-ils/issues/3890.