### PR TITLE
fix(editor): don't remove form field wrapper

### DIFF
--- a/projects/rero/ng-core/src/lib/record/editor/extensions.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/extensions.ts
@@ -29,7 +29,7 @@ export class NgCoreFormlyExtension {
   protected recordService: RecordService = inject(RecordService);
 
   // Types to apply field wrapper on
-  private _fieldWrapperTypes = ['boolean', 'datepicker', 'passwordGenerator'];
+  private _fieldWrapperTypes = ['boolean', 'datepicker', 'passwordGenerator', 'radioButton', 'textarea'];
 
   /**
    * prePopulate Formly hook
@@ -99,11 +99,6 @@ export class NgCoreFormlyExtension {
     // adds form-fields for non standard field types
     if (this._fieldWrapperTypes.some((elem) => elem === field.type) && !field.wrappers.includes('card')) {
       field.wrappers = [...(field.wrappers || []), 'form-field'];
-    }
-
-    // The form-field and the card must not be together
-    if (field.wrappers.includes('card')) {
-      field.wrappers = field.wrappers.filter((value: string) => value != 'form-field');
     }
 
     // TODO: this can be fixed in a future formly release

--- a/projects/rero/ng-core/src/lib/record/editor/type/array-type/array-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/array-type/array-type.component.html
@@ -21,6 +21,11 @@
 }
 
 <div>
+  @if (showError) {
+    <div class="text-error core:my-2">
+      <formly-validation-message [field]="field"/>
+    </div>
+  }
   <!-- for each item -->
   <div [class]="props.containerCssClass">
     @for (f of field.fieldGroup; track f.id) { @if (!f.hide) {

--- a/projects/rero/ng-core/src/lib/record/editor/type/markdown/markdown.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/type/markdown/markdown.component.ts
@@ -40,14 +40,7 @@ export interface FormlyTextAreaFieldConfig extends FormlyFieldConfig<TextAreaPro
 @Component({
     selector: 'ng-core-editor-formly-field-markdown',
     template: `
-    <div class="core:my-2">
       <textarea pTextarea #textarea></textarea>
-      @if (showError) {
-        <div class="text-error core:my-2">
-          <formly-validation-message [field]="field"/>
-        </div>
-      }
-    </div>
   `,
     standalone: false
 })

--- a/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.html
+++ b/projects/rero/ng-core/src/lib/record/editor/type/object-type/object-type.component.html
@@ -14,6 +14,11 @@
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
+@if (showError) {
+  <div class="text-error core:my-2">
+    <formly-validation-message [field]="field"/>
+  </div>
+}
 <div [class]="props.containerCssClass">
   @for (f of field.fieldGroup; track f.id) {
     <!-- the core:scroll-mt-18 class is added for sticky -->

--- a/projects/rero/ng-core/src/lib/record/record.module.ts
+++ b/projects/rero/ng-core/src/lib/record/record.module.ts
@@ -147,7 +147,7 @@ import { SearchTabsComponent } from './search/search-tabs/search-tabs.component'
                 { name: 'boolean', component: SwitchComponent },
                 { name: 'enum', extends: 'select' },
                 { name: 'array', component: ArrayTypeComponent, wrappers: ['card'] },
-                { name: 'object', component: ObjectTypeComponent,  wrappers: ['card'] },
+                { name: 'object', component: ObjectTypeComponent, wrappers: ['card'] },
                 { name: 'multischema', component: MultiSchemaTypeComponent},
                 { name: 'textarea', component: TextareaFieldComponent },
                 { name: 'markdown', component: MarkdownFieldComponent },


### PR DESCRIPTION
The editor's long mode uses the card to set separations. In the case of the card, don't delete the form-wrapper that displays alerts.

* Closes rero/rero-ils#3900.