### PR TITLE
feat(formly): add step validation and locale support to input number

### DIFF
--- a/projects/ng-core-tester/src/app/record/editor/schema.json
+++ b/projects/ng-core-tester/src/app/record/editor/schema.json
@@ -53,7 +53,9 @@
     "name_with_definition",
     "field_expressions",
     "field_with_addon_left_right",
-    "field_radio_button_inline"
+    "field_radio_button_inline",
+    "number_with_2_digits",
+    "round_number"
   ],
   "properties": {
     "date_validator": {
@@ -1628,6 +1630,27 @@
                 "value": "radio_3"
               }
             ]
+          }
+        }
+      }
+    },
+    "number_with_2_digits": {
+      "title": "Number with 2 digits (default)",
+      "default": 2.55,
+      "widget": {
+        "formlyConfig": {
+          "type": "number"
+        }
+      }
+    },
+    "round_number": {
+      "title": "Round Number",
+      "default": 1,
+      "widget": {
+        "formlyConfig": {
+          "type": "number",
+          "props": {
+            "step": 1
           }
         }
       }

--- a/projects/ng-core-tester/src/assets/i18n/de.json
+++ b/projects/ng-core-tester/src/assets/i18n/de.json
@@ -59,5 +59,7 @@
   "Date descending": "Datum absteigend",
   "Date ascending": "Datum aufsteigend",
   "Relevance": "Relevanz",
-  "Title": "Titel"
+  "Title": "Titel",
+  "shouldn't have more than {{decimals}} digit(s) after the decimal point": "sollte nicht mehr als {{decimals}} Stelle(n) hinter dem Dezimalpunkt haben",
+  "should be a whole number": "sollte eine ganze Zahl sein"
 }

--- a/projects/ng-core-tester/src/assets/i18n/en.json
+++ b/projects/ng-core-tester/src/assets/i18n/en.json
@@ -33,5 +33,7 @@
   "Checkbox 4": "Checkbox 4",
   "Radio button 1": "Radio button 1",
   "Radio button 2": "Radio button 2",
-  "Radio button 3": "Radio button 3"
+  "Radio button 3": "Radio button 3",
+  "shouldn't have more than {{decimals}} digit(s) after the decimal point": "shouldn't have more than {{decimals}} digit(s) after the decimal point",
+  "should be a whole number": "should be a whole number"
 }

--- a/projects/ng-core-tester/src/assets/i18n/fr.json
+++ b/projects/ng-core-tester/src/assets/i18n/fr.json
@@ -75,5 +75,7 @@
   "Date descending": "Date décroissante",
   "Date ascending": "Date croissante",
   "Relevance": "Pertinence",
-  "Title": "Titre"
+  "Title": "Titre",
+  "shouldn't have more than {{decimals}} digit(s) after the decimal point": "ne doit pas comporter plus de {{decimals}} chiffre(s) après la virgule",
+  "should be a whole number": "doit être un nombre entier"
 }

--- a/projects/ng-core-tester/src/assets/i18n/it.json
+++ b/projects/ng-core-tester/src/assets/i18n/it.json
@@ -59,5 +59,7 @@
   "Date descending": "Data decrescente",
   "Date ascending": "Data ascendente",
   "Relevance": "Rilevanza",
-  "Title": "Titolo"
+  "Title": "Titolo",
+  "shouldn't have more than {{decimals}} digit(s) after the decimal point": "non dovrebbe avere più di {{decimals}} cifre dopo la virgola",
+  "should be a whole number": "dovrebbe essere un numero intero"
 }

--- a/projects/rero/ng-core/src/lib/core/interceptor/http-pending.interceptor.ts
+++ b/projects/rero/ng-core/src/lib/core/interceptor/http-pending.interceptor.ts
@@ -1,19 +1,5 @@
-/*
- * RERO angular core
- * Copyright (C) 2025 RERO
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, version 3 of the License.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import { HttpEvent, HttpHandlerFn, HttpRequest } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Observable } from 'rxjs';

--- a/projects/rero/ng-core/src/lib/core/service/http-pending/http-pending.service.ts
+++ b/projects/rero/ng-core/src/lib/core/service/http-pending/http-pending.service.ts
@@ -1,19 +1,5 @@
-/*
- * RERO angular core
- * Copyright (C) 2025 RERO
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, version 3 of the License.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import { computed, Injectable, signal } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })

--- a/projects/rero/ng-core/src/lib/formly/config/extensions.spec.ts
+++ b/projects/rero/ng-core/src/lib/formly/config/extensions.spec.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { FormControl, UntypedFormControl } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { addNumberValidators } from './extensions';
+
+const buildField = (type: 'number' | 'integer', props: Record<string, unknown> = {}): FormlyFieldConfig => {
+  const control = new FormControl(null);
+  const field: FormlyFieldConfig = { type, props, formControl: control };
+  addNumberValidators(field);
+  return field;
+};
+
+describe('addNumberValidators', () => {
+  describe('step validator (default 0.01)', () => {
+    it('should be valid when value has at most 2 decimal places', () => {
+      const { formControl } = buildField('number');
+      formControl!.setValue(2.55);
+      expect(formControl!.errors).toBeNull();
+    });
+
+    it('should be invalid when value exceeds 2 decimal places', () => {
+      const { formControl } = buildField('number');
+      formControl!.setValue(2.553);
+      expect(formControl!.errors).toEqual({ step: true });
+    });
+
+    it('should be valid for null value', () => {
+      const { formControl } = buildField('number');
+      formControl!.setValue(null);
+      expect(formControl!.errors).toBeNull();
+    });
+
+    it('should not apply step validator when step is any', () => {
+      const { formControl } = buildField('number', { step: 'any' });
+      formControl!.setValue(2.55333333);
+      expect(formControl!.errors).toBeNull();
+    });
+  });
+
+  describe('step validator (explicit step 1.3)', () => {
+    it('should be valid when value is a multiple of 1.3', () => {
+      const { formControl } = buildField('number', { step: 1.3 });
+      formControl!.setValue(2.6);
+      expect(formControl!.errors).toBeNull();
+    });
+
+    it('should be invalid when value is not a multiple of 1.3', () => {
+      const { formControl } = buildField('number', { step: 1.3 });
+      formControl!.setValue(1.4);
+      expect(formControl!.errors).toEqual({ step: true });
+    });
+
+    it('should be invalid when value has more decimals than step', () => {
+      const { formControl } = buildField('number', { step: 1.3 });
+      formControl!.setValue(1.35);
+      expect(formControl!.errors).toEqual({ step: true });
+    });
+  });
+
+  describe('step validator (explicit step 1)', () => {
+    it('should be valid when value is an integer', () => {
+      const { formControl } = buildField('number', { step: 1 });
+      formControl!.setValue(10);
+      expect(formControl!.errors).toBeNull();
+    });
+
+    it('should be invalid when value has decimals', () => {
+      const { formControl } = buildField('number', { step: 1 });
+      formControl!.setValue(10.5);
+      expect(formControl!.errors).toEqual({ step: true });
+    });
+  });
+
+  describe('min validator', () => {
+    it('should be valid when value equals min', () => {
+      const { formControl } = buildField('number', { min: 1 });
+      formControl!.setValue(1);
+      expect(formControl!.errors).toBeNull();
+    });
+
+    it('should be invalid when value is below min', () => {
+      const { formControl } = buildField('number', { min: 1 });
+      formControl!.setValue(0);
+      expect(formControl!.errors).toEqual({ min: true });
+    });
+  });
+
+  describe('max validator', () => {
+    it('should be valid when value equals max', () => {
+      const { formControl } = buildField('number', { max: 10 });
+      formControl!.setValue(10);
+      expect(formControl!.errors).toBeNull();
+    });
+
+    it('should be invalid when value exceeds max', () => {
+      const { formControl } = buildField('number', { max: 10 });
+      formControl!.setValue(11);
+      expect(formControl!.errors).toEqual({ max: true });
+    });
+  });
+
+  it('should do nothing for non-number fields', () => {
+    const control = new UntypedFormControl(null);
+    const field: FormlyFieldConfig = { type: 'string', props: {}, formControl: control };
+    addNumberValidators(field);
+    control.setValue('hello');
+    expect(control.errors).toBeNull();
+  });
+
+  it('should do nothing when formControl is absent', () => {
+    const field: FormlyFieldConfig = { type: 'number', props: { min: 1 } };
+    expect(() => addNumberValidators(field)).not.toThrow();
+  });
+});

--- a/projects/rero/ng-core/src/lib/formly/config/extensions.ts
+++ b/projects/rero/ng-core/src/lib/formly/config/extensions.ts
@@ -1,13 +1,74 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { inject } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { AbstractControl, UntypedFormControl, ValidationErrors } from '@angular/forms';
 import { FormlyExtension, FormlyFieldConfig, FormlyFieldProps } from '@ngx-formly/core';
 import { _, TranslateService } from '@ngx-translate/core';
 import { DateTime } from 'luxon';
 import { isObservable, of } from 'rxjs';
 import { RecordService } from '../../record/service/record/record.service';
 import { isEmpty, removeEmptyValues } from '../../record/editor/utils/utils';
+
+/**
+ * Adds min/max/step Angular validators directly on the formControl of number/integer fields.
+ * Must run in postPopulate so that FieldValidationExtension has already compiled field._validators.
+ * Exported for testing without requiring Angular DI.
+ */
+export function addNumberValidators(field: FormlyFieldConfig): void {
+  if ((field.type !== 'number' && field.type !== 'integer') || !field.formControl) {
+    return;
+  }
+
+  const control = field.formControl as AbstractControl;
+  if (!field.validation) field.validation = {};
+  if (!field.validation.messages) field.validation.messages = {};
+
+  const min = field.props?.min as number | undefined;
+  if (min !== undefined && !field.validation.messages['min']) {
+    control.addValidators((c: AbstractControl): ValidationErrors | null => {
+      const { value } = c;
+      return value === null || value === undefined || value === '' || Number(value) >= min ? null : { min: true };
+    });
+  }
+
+  const max = field.props?.max as number | undefined;
+  if (max !== undefined && !field.validation.messages['max']) {
+    control.addValidators((c: AbstractControl): ValidationErrors | null => {
+      const { value } = c;
+      return value === null || value === undefined || value === '' || Number(value) <= max ? null : { max: true };
+    });
+  }
+
+  const step = (field.props?.step ?? 0.01) as 'any' | number;
+  if (step !== 'any' && !field.validation.messages['step']) {
+    // Compute stepInt: the integer representation of step at its own decimal precision.
+    // e.g. step=0.4 → factor=10, stepInt=4; step=0.01 → factor=100, stepInt=1.
+    const [, fraction] = step.toString().split('.');
+    const factor = 10 ** (fraction?.length ?? 0);
+    const stepInt = Math.round(step * factor);
+    control.addValidators((c: AbstractControl): ValidationErrors | null => {
+      // Skip empty, null or non-numeric values.
+      if (c.value === null || c.value === undefined || c.value === '') return null;
+      const num = Number(c.value);
+      if (!Number.isFinite(num)) return null;
+      // Work on the string representation to avoid float precision issues.
+      // Split the value into integer and decimal parts as strings.
+      const [intPart, decPart = ''] = String(c.value).split('.');
+      // Reject immediately if the value has more decimal places than step allows.
+      // e.g. step=0.01 (maxDecimals=2): "2.553" → decPart.length=3 > 2 → invalid.
+      if (decPart.length > (fraction?.length ?? 0)) return { step: true };
+      // Pad the decimal part to match step's precision, then concatenate with the
+      // integer part to form a single integer. e.g. step=0.4, value=0.8:
+      // intPart="0", decPart="8" → paddedDec="8" → scaled=8.
+      const paddedDec = decPart.padEnd(fraction?.length ?? 0, '0');
+      const scaled = parseInt(intPart.replace('-', '') + paddedDec, 10);
+      // Check divisibility: scaled=8, stepInt=4 → 8%4=0 → valid.
+      return scaled % stepInt === 0 ? null : { step: true };
+    });
+  }
+
+  control.updateValueAndValidity({ emitEvent: false });
+}
 
 export class NgCoreFormlyExtension {
   protected recordService: RecordService = inject(RecordService);
@@ -68,6 +129,16 @@ export class NgCoreFormlyExtension {
         }
       });
     }
+  }
+
+  /**
+   * postPopulate Formly hook — runs after all extensions including FieldValidationExtension.
+   * Adds min/max/step validators directly on the formControl so they run alongside
+   * the validators compiled by Formly. Messages are stored in field.validation.messages
+   * so formly-validation-message can resolve them from formControl.errors.
+   */
+  postPopulate(field: FormlyFieldConfig): void {
+    addNumberValidators(field);
   }
 
   /**
@@ -229,6 +300,7 @@ export class NgCoreFormlyExtension {
       }
     }
   }
+
 
   /**
    * Set custom validators from the props configuration.
@@ -592,6 +664,18 @@ export function registerNgCoreFormlyExtension(translate: TranslateService): Reco
         name: 'const',
         message: (_err: unknown, field: FormlyFieldConfig) =>
           translate.stream(_('should be equal to constant "{{const}}"'), { const: field.props!.const }),
+      },
+      {
+        name: 'step',
+        message: (_err: unknown, field: FormlyFieldConfig) => {
+          const step = field.props?.['step'] ?? 0.01;
+          const parts = step.toString().split('.');
+          const decimals = parts.length > 1 ? parts[1].length : 0;
+          if (step === 1) {
+            return translate.instant(_("should be a whole number"));
+          }
+          return translate.instant(_("shouldn't have more than {{decimals}} digit(s) after the decimal point"), { decimals });
+        },
       },
     ],
     extensions: [

--- a/projects/rero/ng-core/src/lib/formly/types/input/input.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/formly/types/input/input.component.spec.ts
@@ -44,7 +44,7 @@ describe('ui-primeng: NgCore Input Type', () => {
     expect(attributes.step).toBeUndefined();
   });
 
-  it('should have the default step parameter set to number on a number field', () => {
+  it('should have the default step and maxFractionDigits on a number field', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
@@ -52,23 +52,75 @@ describe('ui-primeng: NgCore Input Type', () => {
         type: 'number',
       },
     });
-    expect(query('input')).not.toBeNull();
-    const { attributes } = query('input');
-    expect(attributes.type).toEqual('number');
-    expect(attributes.step).toEqual('number');
+    expect(query('p-inputnumber')).not.toBeNull();
+    const inputNumber = query('p-inputnumber').componentInstance;
+    expect(inputNumber.step()).toEqual(0.01);
+    expect(inputNumber.maxFractionDigits).toEqual(2);
   });
 
-  it('should have the step parameter set to 0.5 on a number field', () => {
+  it('should have step and maxFractionDigits set from a custom step', () => {
     const { query } = renderComponent({
       key: 'name',
       type: 'input',
       props: {
         type: 'number',
-        inputStep: 0.5,
+        step: 0.5,
       },
     });
-    const { attributes } = query('input');
-    expect(attributes.type).toEqual('number');
-    expect(attributes.step).toEqual('0.5');
+    const inputNumber = query('p-inputnumber').componentInstance;
+    expect(inputNumber.step()).toEqual(0.5);
+    expect(inputNumber.maxFractionDigits).toEqual(1);
   });
+
+  it('should have no step and maxFractionDigits set to 20 when step is any', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'input',
+      props: {
+        type: 'number',
+        step: 'any' as any,
+      },
+    });
+    const inputNumber = query('p-inputnumber').componentInstance;
+    expect(inputNumber.step()).toBeUndefined();
+    expect(inputNumber.maxFractionDigits).toEqual(20);
+  });
+
+  it('should render p-inputnumber for a number field regardless of locale', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'input',
+      props: {
+        type: 'number',
+      },
+    });
+    expect(query('p-inputnumber')).not.toBeNull();
+    expect(query('input[type="number"]')).toBeNull();
+  });
+
+  it('should show buttons by default on a number field', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'input',
+      props: {
+        type: 'number',
+      },
+    });
+    const inputNumber = query('p-inputnumber').componentInstance;
+    expect(inputNumber.showButtons).toBe(true);
+  });
+
+  it('should hide buttons when showButtons is set to false', () => {
+    const { query } = renderComponent({
+      key: 'name',
+      type: 'input',
+      props: {
+        type: 'number',
+        showButtons: false,
+      },
+    });
+    const inputNumber = query('p-inputnumber').componentInstance;
+    expect(inputNumber.showButtons).toBe(false);
+  });
+
 });

--- a/projects/rero/ng-core/src/lib/formly/types/input/input.component.ts
+++ b/projects/rero/ng-core/src/lib/formly/types/input/input.component.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
+import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Type } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FieldType, FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { InputGroup } from 'primeng/inputgroup';
 import { InputGroupAddon } from 'primeng/inputgroupaddon';
-import { NgTemplateOutlet, NgClass } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { InputNumber } from 'primeng/inputnumber';
 import { InputText } from 'primeng/inputtext';
 
 export interface NgCoreFormlyInputFieldConfig extends FormlyFieldConfig {
@@ -13,7 +14,9 @@ export interface NgCoreFormlyInputFieldConfig extends FormlyFieldConfig {
   addonRight?: string[];
   addonLeft?: string[];
   class?: string;
-  inputStep?: string | number;
+  step?: 'any' | number;
+  locale?: string;
+  showButtons?: boolean;
 }
 
 @Component({
@@ -38,11 +41,13 @@ export interface NgCoreFormlyInputFieldConfig extends FormlyFieldConfig {
     }
     <ng-template #input let-formControl="formControl" let-props="props" let-field="field" let-showError="showError">
       @if (props.type === 'number') {
-        <input
-          pInputText
-          [class]="props.class"
-          type="number"
-          [attr.step]="props.inputStep"
+        <p-inputnumber
+          [inputStyleClass]="props.class"
+          [locale]="props.locale"
+          [step]="props.step === 'any' ? undefined : (props.step ?? 0.01)"
+          [minFractionDigits]="0"
+          [maxFractionDigits]="props.step === 'any' ? 20 : decimalPlaces(props.step ?? 0.01)"
+          [showButtons]="props.showButtons ?? true"
           [formControl]="formControl"
           [formlyAttributes]="field"
           [ngClass]="{ 'ng-invalid ng-dirty': showError }"
@@ -66,6 +71,7 @@ export interface NgCoreFormlyInputFieldConfig extends FormlyFieldConfig {
     NgTemplateOutlet,
     FormsModule,
     InputText,
+    InputNumber,
     ReactiveFormsModule,
     FormlyModule,
     NgClass,
@@ -75,7 +81,12 @@ export class InputComponent extends FieldType<NgCoreFormlyInputFieldConfig> {
   defaultOptions? = {
     props: {
       class: 'core:w-full',
-      inputStep: 'number',
     },
   };
+
+  decimalPlaces(step: 'any' | number | undefined): number {
+    if (!step || step === 'any') return 0;
+    const parts = step.toString().split('.');
+    return parts.length > 1 ? parts[1].length : 0;
+  }
 }


### PR DESCRIPTION
* Rename inputStep to step with type 'any' | number.
* Add Angular validator enforcing decimal precision based on step.
* Always render p-inputnumber for number fields, fixing Firefox letting invalid characters be typed in a native input[type=number].
* Add showButtons prop (default true) to toggle the increment/decrement buttons.
* Add step validation message in extensions with specific messagefor whole numbers.