### PR TITLE
fix(search): show full-text search fields toggle before querying

### DIFF
--- a/projects/rero/ng-core/src/lib/record/component/search/record-search/record-search.component.html
+++ b/projects/rero/ng-core/src/lib/record/component/search/record-search/record-search.component.html
@@ -69,11 +69,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
           config().searchFilters.length > 0
         ) {
           <div class="core:md:col-span-5 core:lg:col-span-3 core:col-span-12">
-            @if (config().searchFields.length > 0 && store.q()) {
+            @if (config().searchFields.length > 0) {
               <div class="core:flex core:flex-col core:gap-1 core:mb-2">
-                @for (searchField of config().searchFields; track $index) {
+                @for (searchField of config().searchFields; track searchField.path) {
                   <div class="core:flex core:gap-2 core:items-center">
-                    <p-toggleswitch (onChange)="searchInField($event, searchField.path)" />
+                    <p-toggleswitch
+                      [ngModel]="isFieldSelected(searchField.path)"
+                      (onChange)="searchInField($event, searchField.path)"
+                    />
                     <span>{{ searchField.label | translate }}</span>
                   </div>
                 }

--- a/projects/rero/ng-core/src/lib/record/component/search/record-search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/record-search/record-search.component.ts
@@ -13,6 +13,7 @@ import {
   Signal,
 } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { NgxSpinnerService } from 'ngx-spinner';
@@ -51,6 +52,7 @@ import { SearchTabsComponent } from './search-tabs/search-tabs.component';
     Message,
     Button,
     RouterLink,
+    FormsModule,
     MenuSortComponent,
     ExportButtonComponent,
     ListFiltersComponent,
@@ -269,14 +271,25 @@ export class RecordSearchComponent {
     return of(aggregations);
   }
 
+  /**
+   * Whether a search field is currently selected.
+   * The selection state lives in the store; defaults to false before any interaction.
+   * @param path - The search field path
+   * @returns True if the field is selected.
+   */
+  isFieldSelected(path: string): boolean {
+    return this.store.searchFields().find((field: SearchField) => field.path === path)?.selected ?? false;
+  }
+
   searchInField(event: ToggleSwitchChangeEvent, path: string): void {
+    // Rebuild the field list from the config (the authoritative source used for display)
+    // while preserving the current selection held in the store.
+    const selection = this.store.searchFields();
     this.store.updateSearchFields(
-      this.store.config().searchFields.map((item: SearchField) => {
-        if (item.path === path) {
-          item.selected = event.checked;
-        }
-        return item;
-      }),
+      this.config().searchFields.map((field: SearchField) => ({
+        ...field,
+        selected: field.path === path ? event.checked : (selection.find((f) => f.path === field.path)?.selected ?? false),
+      })),
     );
     // If query string is specified, search is processed.
     const q = this.store.q();

--- a/projects/rero/ng-core/src/lib/record/component/search/store/features/with-search-fields.feature.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/features/with-search-fields.feature.ts
@@ -3,7 +3,6 @@
 import { computed, inject, Injector, Signal } from '@angular/core';
 import { patchState, signalStoreFeature, type, withComputed, withHooks, withMethods } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { TranslateService } from '@ngx-translate/core';
 import { filter, pipe, tap } from 'rxjs';
 import { SearchField } from '../../../../../model/record.interface';
 import { RecordType } from '../../../../model';
@@ -35,7 +34,6 @@ export function withSearchFields() {
       }>(),
       props: type<{
         config: Signal<RecordType>;
-        translateService?: TranslateService;
       }>(),
     },
     withComputed((state) => ({
@@ -100,9 +98,9 @@ export function withSearchFields() {
           filter((params) => params.config.searchFields.length > 0),
           tap((params) => {
             const configFields = params.config.searchFields;
+            // Keep the raw label (translation key); the view translates it reactively.
             const fieldsWithSelection = configFields.map((field) => ({
               ...field,
-              label: store.translateService?.instant ? store.translateService.instant(field.label) : field.label,
               selected: field.selected ?? false,
             }));
 

--- a/projects/rero/ng-core/src/lib/record/component/search/store/features/with-search-params.feature.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/features/with-search-params.feature.spec.ts
@@ -115,6 +115,27 @@ describe('withSearchParams', () => {
       // Must run inside an injection context so rxMethod can resolve DestroyRef
       expect(() => TestBed.runInInjectionContext(() => store.syncUrlParams(urlParams$))).not.toThrow();
     });
+
+    it('should preserve searchFields/searchFilters selection when syncing URL params', () => {
+      const store = TestBed.inject(TestStore);
+
+      // The user has selected a search field and filters are loaded in the store.
+      patchState(store, {
+        q: 'old',
+        searchFields: [{ path: 'fulltext', label: 'Full-text', selected: true }],
+        searchFilters: [{ label: 'Open access', filter: 'open_access', value: '1' }],
+      });
+
+      // URL sync emits params without searchFields/searchFilters (they are never carried in the URL).
+      const urlParams$ = new BehaviorSubject({ q: 'new', searchFields: [], searchFilters: [] });
+      TestBed.runInInjectionContext(() => store.syncUrlParams(urlParams$));
+
+      // The URL-carried value (q) is applied...
+      expect(store.q()).toBe('new');
+      // ...but the user's field selection and loaded filters must not be reset.
+      expect(store.searchFields()).toEqual([{ path: 'fulltext', label: 'Full-text', selected: true }]);
+      expect(store.searchFilters()).toEqual([{ label: 'Open access', filter: 'open_access', value: '1' }]);
+    });
   });
 
   describe('patchState', () => {

--- a/projects/rero/ng-core/src/lib/record/component/search/store/features/with-search-params.feature.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/features/with-search-params.feature.ts
@@ -123,7 +123,11 @@ export function withSearchParams() {
               return;
             }
 
-            patchState(store, urlParams);
+            // searchFields/searchFilters are not carried in the URL (always empty here),
+            // so they must be excluded from the patch to avoid resetting the user's
+            // current selection on every URL synchronization.
+            const { searchFields, searchFilters, ...patch } = urlParams;
+            patchState(store, patch);
           }),
         ),
       ),


### PR DESCRIPTION
The "search in full-text" toggle was only rendered once a query had been typed, hiding the fact that full-text search is opt-in. It now displays by default in an off state so the limitation is discoverable.

- Render the search-fields toggle from `config().searchFields` regardless of the current query (drop the `&& store.q()` condition).
- Bind the toggle to the store selection via `[ngModel]`/`isFieldSelected` and update it immutably, mirroring the search-filters component pattern.
- Keep the raw label (translation key) in the store; let the view translate it so it stays reactive to language changes.
- Stop `syncUrlParams` from resetting `searchFields`/`searchFilters`, which are never carried in the URL — this fixes the toggle being switched off when a search is launched.

rero-ils is unaffected (it does not configure `searchFields`).

Closes rero/sonar#671