### PR TITLE
refactor(translate): extensible loading per app

### DIFF
--- a/.ai/commit-conventions.md
+++ b/.ai/commit-conventions.md
@@ -1,0 +1,51 @@
+<!--
+SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Commit Conventions
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+## Format
+
+```text
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+## Rules
+
+- **Subject line**: must not exceed **50 characters** (including type and scope).
+- **Body lines**: each line must not exceed **72 characters**.
+- **Subject**: use the imperative mood, lowercase, no trailing period.
+- **Body**: explain *what* and *why*, not *how*. Separate from subject with a blank line.
+- **Body lists**: use `*` (asterisk) for bullet points, never `-` (dash).
+- **Footer**: used for breaking changes (`BREAKING CHANGE:`) and issue references.
+
+## Types
+
+| Type       | When to use                                      |
+|------------|--------------------------------------------------|
+| `feat`     | A new feature                                    |
+| `fix`      | A bug fix                                        |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test`     | Adding or correcting tests                       |
+| `docs`     | Documentation only changes                       |
+| `style`    | Formatting, missing semicolons, etc.             |
+| `chore`    | Build process, dependency updates, tooling       |
+| `perf`     | Performance improvement                          |
+| `ci`       | CI/CD configuration changes                      |
+
+## Examples
+
+```text
+feat(search): add full-text filter by date range
+
+fix(editor): prevent double-save on rapid submit
+
+refactor(translate): extensible loading per app
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,4 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 @.ai/angular-patterns.md
 @.ai/testing-rules.md
 @.ai/dev-commands.md
+@.ai/commit-conventions.md

--- a/angular.json
+++ b/angular.json
@@ -51,7 +51,20 @@
             },
             "index": "projects/ng-core-tester/src/index.html",
             "tsConfig": "projects/ng-core-tester/tsconfig.app.json",
-            "assets": ["projects/ng-core-tester/src/favicon.ico", "projects/ng-core-tester/src/assets"],
+            "assets": [
+              "projects/ng-core-tester/src/favicon.ico",
+              "projects/ng-core-tester/src/assets",
+              {
+                "glob": "*.json",
+                "input": "projects/rero/ng-core/src/lib/translate/i18n",
+                "output": "assets/ng-core/i18n"
+              },
+              {
+                "glob": "*.json",
+                "input": "projects/rero/ng-core/src/lib/translate/languages",
+                "output": "assets/ng-core/languages"
+              }
+            ],
             "styles": ["projects/ng-core-tester/src/styles.scss"],
             "stylePreprocessorOptions": {
               "includePaths": ["projects/rero/ng-core/assets/scss"]

--- a/projects/ng-core-tester/src/app/app-config.service.ts
+++ b/projects/ng-core-tester/src/app/app-config.service.ts
@@ -23,7 +23,6 @@ export class AppConfigService extends CoreConfigService {
     if (environment.$refPrefix) {
       this.$refPrefix = environment.$refPrefix;
     }
-    this.languages = environment.languages;
     this.translationsURLs = environment.translationsURLs;
   }
 }

--- a/projects/ng-core-tester/src/app/app-translate-loader.ts
+++ b/projects/ng-core-tester/src/app/app-translate-loader.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { Injectable } from '@angular/core';
+import { CORE_TRANSLATION_LOADERS, CoreTranslateLoader, TranslationLoaderFn } from '@rero/ng-core';
+
+const ngCoreI18n = (lang: string): TranslationLoaderFn =>
+  () => fetch(`/assets/ng-core/i18n/${lang}.json`)
+    .then(r => r.json())
+    .then(data => ({ default: data }));
+
+@Injectable()
+export class AppTranslateLoader extends CoreTranslateLoader {
+  protected override coreTranslationLoaders: Record<string, TranslationLoaderFn> = {
+    ...CORE_TRANSLATION_LOADERS,
+    de: ngCoreI18n('de'),
+    fr: ngCoreI18n('fr'),
+    it: ngCoreI18n('it'),
+  };
+}

--- a/projects/ng-core-tester/src/app/app-translate.service.ts
+++ b/projects/ng-core-tester/src/app/app-translate.service.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import localeDe from '@angular/common/locales/de';
+import localeFr from '@angular/common/locales/fr';
+import localeIt from '@angular/common/locales/it';
+import { Injectable } from '@angular/core';
+import { CORE_LOCALES, Locales, NgCoreTranslateService } from '@rero/ng-core';
+import { de } from 'primelocale/js/de.js';
+import { fr } from 'primelocale/js/fr.js';
+import { it } from 'primelocale/js/it.js';
+
+@Injectable({ providedIn: 'root' })
+export class AppTranslateService extends NgCoreTranslateService {
+  protected override locales: Locales = {
+    ...CORE_LOCALES,
+    de: { angular: localeDe, primeng: de },
+    fr: { angular: localeFr, primeng: fr },
+    it: { angular: localeIt, primeng: it },
+  };
+}

--- a/projects/ng-core-tester/src/app/app.config.ts
+++ b/projects/ng-core-tester/src/app/app.config.ts
@@ -2,26 +2,25 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import { httpPendingInterceptor } from '@rero/ng-core';
-import { ApplicationConfig, inject, provideEnvironmentInitializer } from '@angular/core';
+import { ApplicationConfig, inject, provideAppInitializer } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { provideTranslateLoader, provideTranslateService, TranslateService } from '@ngx-translate/core';
 import {
-  CoreConfigService,
-  CoreTranslateLoader,
-  NgCoreTranslateService,
-  primeNGConfig,
+  CoreConfigService, httpPendingInterceptor, NgCoreTranslateService, primeNGConfig,
   provideCore,
   RecordService,
-  RemoteAutocompleteService,
+  RemoteAutocompleteService, TranslateLanguageService
 } from '@rero/ng-core';
 import { providePrimeNG } from 'primeng/config';
-import { firstValueFrom } from 'rxjs';
 import { AppConfigService } from './app-config.service';
+import { AppTranslateLoader } from './app-translate-loader';
+import { AppTranslateService } from './app-translate.service';
 import { routes } from './app.routes';
 import { RecordServiceMock } from './record/editor/record-service-mock';
+import { AppInitializerService } from './service/app-initializer.service';
 import { AppRemoteAutocompleteService } from './service/app-remote-autocomplete.service';
+import { AppTranslateLanguageService } from './service/app-translate-language.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -29,17 +28,12 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideHttpClient(withInterceptors([httpPendingInterceptor])),
     provideTranslateService({
-      loader: provideTranslateLoader(CoreTranslateLoader),
+      loader: provideTranslateLoader(AppTranslateLoader),
     }),
-    provideEnvironmentInitializer(async () => {
-      const translateService = inject(TranslateService);
-      const configService = inject(CoreConfigService);
-      const availableLanguages: string[] = configService.languages ?? ['en'];
-      const browserLang = navigator.language.split('-')[0];
-      const lang = availableLanguages.includes(browserLang) ? browserLang : availableLanguages[0];
-      await firstValueFrom(translateService.use(lang));
-    }),
-    { provide: TranslateService, useExisting: NgCoreTranslateService },
+    provideAppInitializer(() => inject(AppInitializerService).initialize()),
+    { provide: TranslateService, useExisting: AppTranslateService },
+    { provide: NgCoreTranslateService, useExisting: AppTranslateService },
+    { provide: TranslateLanguageService, useExisting: AppTranslateLanguageService },
     provideAnimations(),
     providePrimeNG(primeNGConfig),
     {

--- a/projects/ng-core-tester/src/app/home/home.component.html
+++ b/projects/ng-core-tester/src/app/home/home.component.html
@@ -33,6 +33,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <p-panel header="Translate Language pipe" class="ui:mt-4 ui:pb-4">
   <div class="ui:pl-4">
     <p>
+      Translate "fre" with current language: <strong>{{ 'fre' | translateLanguage }}</strong>
+    </p>
+    <p>
       Translate "fre" code in german: <strong>{{ 'fre' | translateLanguage: 'de' }}</strong>
     </p>
     <p>

--- a/projects/ng-core-tester/src/app/menu/menu.component.ts
+++ b/projects/ng-core-tester/src/app/menu/menu.component.ts
@@ -1,15 +1,17 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, WritableSignal, inject, signal } from '@angular/core';
+import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
-import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
-import { CONFIG, Config, CoreConfigService } from '@rero/ng-core';
+import { TranslateService } from '@ngx-translate/core';
+import { CONFIG } from '@rero/ng-core';
 import { MenuItem, MessageService } from 'primeng/api';
-import { Subscription } from 'rxjs';
+import { Badge } from 'primeng/badge';
 import { Menubar } from 'primeng/menubar';
 import { Ripple } from 'primeng/ripple';
-import { Badge } from 'primeng/badge';
-import { NgClass } from '@angular/common';
+import { map } from 'rxjs';
+import { AppUserService, UserInfo } from '../service/app-user.service';
 
 @Component({
   selector: 'app-menu',
@@ -17,21 +19,27 @@ import { NgClass } from '@angular/common';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [Menubar, Ripple, RouterLink, Badge, NgClass],
 })
-export class MenuComponent implements OnInit, OnDestroy {
+export class MenuComponent {
   messageService = inject(MessageService);
   translateService = inject(TranslateService);
   router = inject(Router);
-  config: Config = inject(CoreConfigService);
+  userService = inject(AppUserService);
 
-  menuItems: WritableSignal<MenuItem[]> = signal([]);
+  private currentLang: Signal<string> = toSignal(
+    this.translateService.onLangChange.pipe(map((event) => event.lang)),
+    { initialValue: this.translateService.getCurrentLang() },
+  );
 
-  subscription = new Subscription();
+  private userInfo: Signal<UserInfo | undefined> = toSignal(this.userService.getUserInfo());
 
-  ngOnInit(): void {
-    this.menuItems.set([
+  menuItems: Signal<MenuItem[]> = computed(() => this.buildMenu(this.userInfo(), this.currentLang()));
+
+  private buildMenu(userInfo: UserInfo | undefined, currentLang: string): MenuItem[] {
+    const availableLanguages = userInfo?.settings.availableLanguages.map((l) => l.code) ?? [];
+
+    return [
       {
         label: this.translateService.instant('home'),
-        untranslatedLabel: 'home',
         icon: 'fa-solid fa-house',
         command: () => {
           this.router.navigate(['/']);
@@ -40,41 +48,34 @@ export class MenuComponent implements OnInit, OnDestroy {
       },
       {
         label: this.translateService.instant('Records'),
-        untranslatedLabel: 'Records',
         id: 'records',
         items: [
           {
             label: this.translateService.instant('Global records'),
-            untranslatedLabel: 'Global records',
             icon: 'fa-solid fa-book',
             routerLink: ['/record', 'search', 'documents'],
           },
           {
             label: this.translateService.instant('UNISI records'),
-            untranslatedLabel: 'UNISI records',
             icon: 'fa-solid fa-book',
             routerLink: ['/unisi', 'record', 'search', 'documents'],
           },
           {
             label: this.translateService.instant('Backend records'),
-            untranslatedLabel: 'Backend records',
             icon: 'fa-solid fa-book',
             routerLink: ['/admin', 'record', 'search', 'documents'],
           },
           {
             label: this.translateService.instant('Documents'),
-            untranslatedLabel: 'Documents',
             icon: 'fa-solid fa-book',
             items: [
               {
                 label: this.translateService.instant('Document records'),
-                untranslatedLabel: 'Document records',
                 icon: 'fa-solid fa-book',
                 routerLink: ['/records', 'documents'],
               },
               {
                 label: this.translateService.instant('Document records with query params'),
-                untranslatedLabel: 'Document records with query params',
                 icon: 'fa-solid fa-book',
                 routerLink: ['/records', 'documents'],
                 queryParams: { q: 'anatomic', page: 1, size: 10 },
@@ -83,7 +84,6 @@ export class MenuComponent implements OnInit, OnDestroy {
           },
           {
             label: this.translateService.instant('Organisation'),
-            untranslatedLabel: 'Organisation',
             icon: 'fa-solid fa-industry',
             routerLink: ['/records', 'organisations'],
           },
@@ -93,7 +93,6 @@ export class MenuComponent implements OnInit, OnDestroy {
           },
           {
             label: this.translateService.instant('Editor'),
-            untranslatedLabel: 'Editor',
             icon: 'fa-solid fa-pen-to-square',
             items: [
               {
@@ -101,13 +100,11 @@ export class MenuComponent implements OnInit, OnDestroy {
                 items: [
                   {
                     label: this.translateService.instant('Add mode'),
-                    untranslatedLabel: 'Add mode',
                     icon: 'fa-solid fa-circle-plus',
                     routerLink: ['/editor', 'demo'],
                   },
                   {
                     label: this.translateService.instant('Edit mode'),
-                    untranslatedLabel: 'Edit mode',
                     icon: 'fa-solid fa-pencil',
                     routerLink: ['/editor', 'demo', '1'],
                   },
@@ -118,13 +115,11 @@ export class MenuComponent implements OnInit, OnDestroy {
                 items: [
                   {
                     label: this.translateService.instant('Add mode'),
-                    untranslatedLabel: 'Add mode',
                     icon: 'fa-solid fa-circle-plus',
                     routerLink: ['/editor', 'normal'],
                   },
                   {
                     label: this.translateService.instant('Edit mode'),
-                    untranslatedLabel: 'Edit mode',
                     icon: 'fa-solid fa-pencil',
                     routerLink: ['/editor', 'normal', '1'],
                   },
@@ -143,21 +138,12 @@ export class MenuComponent implements OnInit, OnDestroy {
       },
       {
         label: this.translateService.instant('Language'),
-        untranslatedLabel: 'Language',
         id: 'language',
         icon: 'fa-solid fa-language',
-        items: [],
-      },
-    ]);
-
-    const languageMenu: MenuItem | undefined = this.menuItems().find((item: MenuItem) => item.id === 'language');
-    if (languageMenu !== undefined) {
-      this.config.languages?.forEach((language: string) => {
-        const lang = {
+        items: availableLanguages.map((language) => ({
           label: this.translateService.instant(language),
-          untranslatedLabel: language,
           id: language,
-          styleClass: undefined,
+          styleClass: language === currentLang ? 'ui:font-bold' : '',
           command: () => {
             this.translateService.use(language);
             this.messageService.add({
@@ -167,38 +153,8 @@ export class MenuComponent implements OnInit, OnDestroy {
               life: CONFIG.MESSAGE_LIFE,
             });
           },
-        };
-        languageMenu.items?.push(lang);
-      });
-    }
-    this.subscription.add(
-      this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
-        const menu = this.translateItems(this.menuItems());
-        const language = menu.find((item: MenuItem) => item.id === 'language');
-        if (language !== undefined) {
-          language.items?.map((item: MenuItem) => {
-            item.styleClass = item.id === event.lang ? 'ui:font-bold' : '';
-          });
-        }
-        this.menuItems.set([...menu]);
-      }),
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
-  }
-
-  private translateItems(menuItems: MenuItem[]): MenuItem[] {
-    menuItems.map((item: MenuItem) => {
-      if (item.untranslatedLabel) {
-        item.label = this.translateService.instant(item.untranslatedLabel);
-      }
-      if (item.items) {
-        this.translateItems(item.items);
-      }
-    });
-
-    return menuItems;
+        })),
+      },
+    ];
   }
 }

--- a/projects/ng-core-tester/src/app/service/app-initializer.service.ts
+++ b/projects/ng-core-tester/src/app/service/app-initializer.service.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { inject, Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { AppTranslateLanguageService } from './app-translate-language.service';
+import { from, Observable, switchMap } from 'rxjs';
+import { AppUserService } from './app-user.service';
+
+@Injectable({ providedIn: 'root' })
+export class AppInitializerService {
+  private translateService = inject(TranslateService);
+  private userService = inject(AppUserService);
+  private translateLanguageService = inject(AppTranslateLanguageService);
+
+  initialize(): Observable<unknown> {
+    return this.userService.getUserInfo().pipe(
+      switchMap((userInfo) => {
+        const availableLanguages = userInfo.settings.availableLanguages.map((l) => l.code);
+        this.translateService.addLangs(availableLanguages);
+
+        return from(this.translateLanguageService.initialize()).pipe(
+          switchMap(() => {
+            const preferred = userInfo.settings.language;
+            const browserLang = navigator.language.split('-')[0];
+            const lang = availableLanguages.includes(preferred)
+              ? preferred
+              : availableLanguages.includes(browserLang)
+                ? browserLang
+                : (availableLanguages[0] ?? 'en');
+
+            return this.translateService.use(lang);
+          }),
+        );
+      }),
+    );
+  }
+}

--- a/projects/ng-core-tester/src/app/service/app-translate-language.service.ts
+++ b/projects/ng-core-tester/src/app/service/app-translate-language.service.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { Injectable } from '@angular/core';
+import { LanguageLoaderFn, TranslateLanguageService } from '@rero/ng-core';
+
+const ngCoreLanguage = (lang: string): LanguageLoaderFn =>
+  () => fetch(`/assets/ng-core/languages/${lang}.json`).then(r => r.json());
+
+@Injectable({ providedIn: 'root' })
+export class AppTranslateLanguageService extends TranslateLanguageService {
+  initialize(): Promise<void> {
+    return this.loadLanguages({
+      de: ngCoreLanguage('de'),
+      fr: ngCoreLanguage('fr'),
+      it: ngCoreLanguage('it'),
+    });
+  }
+}

--- a/projects/ng-core-tester/src/app/service/app-user.service.ts
+++ b/projects/ng-core-tester/src/app/service/app-user.service.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+export interface AvailableLanguage {
+  code: string;
+  name: string;
+}
+
+export interface UserSettings {
+  language: string;
+  availableLanguages: AvailableLanguage[];
+}
+
+export interface UserInfo {
+  settings: UserSettings;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AppUserService {
+  getUserInfo(): Observable<UserInfo> {
+    return of({
+      settings: {
+        language: 'en',
+        availableLanguages: [
+          { code: 'en', name: 'English' },
+          { code: 'fr', name: 'French' },
+          { code: 'de', name: 'German' },
+          { code: 'it', name: 'Italian' },
+        ],
+      },
+    });
+  }
+}

--- a/projects/ng-core-tester/src/environments/environment.prod.ts
+++ b/projects/ng-core-tester/src/environments/environment.prod.ts
@@ -5,6 +5,5 @@ export const environment = {
   projectTitle: 'NG-Core',
   apiBaseUrl: '',
   $refPrefix: 'https://sonar.ch',
-  languages: ['fr', 'de', 'it', 'en'],
   translationsURLs: ['/assets/i18n/${lang}.json'],
 };

--- a/projects/ng-core-tester/src/environments/environment.ts
+++ b/projects/ng-core-tester/src/environments/environment.ts
@@ -10,6 +10,5 @@ export const environment = {
   projectTitle: 'NG-Core',
   apiBaseUrl: '',
   $refPrefix: 'https://sonar.ch',
-  languages: ['fr', 'de', 'it', 'en'],
   translationsURLs: ['/assets/i18n/${lang}.json'],
 };

--- a/projects/ng-core-tester/tsconfig.app.json
+++ b/projects/ng-core-tester/tsconfig.app.json
@@ -8,6 +8,6 @@
       "@rero/ng-core": ["../../dist/rero/ng-core"]
     }
   },
-  "files": ["src/main.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["src/**/*.ts", "src/**/*.json"],
+  "exclude": ["**/*.spec.ts"]
 }

--- a/projects/rero/ng-core/ng-package.json
+++ b/projects/rero/ng-core/ng-package.json
@@ -11,8 +11,7 @@
     "marked",
     "primelocale"
   ],
-  "assets": ["./assets/**/*.scss", "./src/**/*.scss"
-],
+  "assets": ["./assets/**/*.scss", "./src/**/*.scss", "./src/lib/translate/i18n/*.json", "./src/lib/translate/languages/*.json"],
   "lib": {
     "entryFile": "src/public-api.ts"
   }

--- a/projects/rero/ng-core/src/lib/core/interceptor/http-pending.interceptor.ts
+++ b/projects/rero/ng-core/src/lib/core/interceptor/http-pending.interceptor.ts
@@ -14,12 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { HttpHandlerFn, HttpRequest } from '@angular/common/http';
+import { HttpEvent, HttpHandlerFn, HttpRequest } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { HttpPendingService } from '../service/http-pending/http-pending.service';
 
-export function httpPendingInterceptor(req: HttpRequest<unknown>, next: HttpHandlerFn) {
+export function httpPendingInterceptor(req: HttpRequest<unknown>, next: HttpHandlerFn): Observable<HttpEvent<unknown>> {
   if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
     const service = inject(HttpPendingService);
     service.increment();

--- a/projects/rero/ng-core/src/lib/core/service/core-config/core-config.service.ts
+++ b/projects/rero/ng-core/src/lib/core/service/core-config/core-config.service.ts
@@ -12,10 +12,10 @@ export interface Config {
   apiEndpointPrefix?: string;
   $refPrefix?: string;
   schemaFormEndpoint: string;
-  languages?: string[];
   defaultLanguage?: string;
   secretPassphrase: string;
   translationsURLs?: string[];
+  ngCoreAssetsUrl?: string;
 }
 
 /**
@@ -31,8 +31,8 @@ export class CoreConfigService implements Config {
   apiEndpointPrefix = '/api';
   schemaFormEndpoint = '/api/schemaform';
   $refPrefix = '';
-  languages = ['en'];
   defaultLanguage = 'en';
   secretPassphrase = 'ShERWIN53SnAggIng48rELAtiVes';
   translationsURLs: string[] = [];
+  ngCoreAssetsUrl = '';
 }

--- a/projects/rero/ng-core/src/lib/record/component/autocomplete/search-autocomplete.component.ts
+++ b/projects/rero/ng-core/src/lib/record/component/autocomplete/search-autocomplete.component.ts
@@ -86,13 +86,13 @@ export class SearchAutocompleteComponent implements AfterViewInit {
 
   // Input
   delay = input<number>(300);
-  groupClass = input<string>('core:text-gray-400');
-  inputStyleClass = input<string>('core:w-full');
+  groupClass = input<string|undefined>('core:text-gray-400');
+  inputStyleClass = input<string|undefined>('core:w-full');
   minLength = input<number>(3);
   placeholder = input<string>();
   recordTypes = input.required<AutoCompleteRecordType[]>();
   scrollHeight = input<string>(CONFIG.DEFAULT_SELECT_SCROLL_HEIGHT);
-  styleClass = input<string>('core:w-full');
+  styleClass = input<string|undefined>('core:w-full');
   value = input.required<string>();
 
   // Output

--- a/projects/rero/ng-core/src/lib/translate/loader/translate-loader.spec.ts
+++ b/projects/rero/ng-core/src/lib/translate/loader/translate-loader.spec.ts
@@ -17,7 +17,11 @@ describe('CoreTranslateLoader', () => {
         TranslateModule.forRoot({
           loader: {
             provide: TranslateLoader,
-            useFactory: () => new CoreTranslateLoader(),
+            useFactory: () => {
+            const loader = new CoreTranslateLoader();
+            (loader as any).coreTranslationLoaders = {};
+            return loader;
+          },
             deps: [HttpClient],
           },
         }),

--- a/projects/rero/ng-core/src/lib/translate/loader/translate-loader.ts
+++ b/projects/rero/ng-core/src/lib/translate/loader/translate-loader.ts
@@ -3,75 +3,72 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { TranslateLoader, TranslationObject } from '@ngx-translate/core';
-import { forkJoin, Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { forkJoin, from, Observable, of } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { CoreConfigService } from '../../core';
-import de from '../i18n/de.json' with { type: 'json' };
-import en from '../i18n/en.json' with { type: 'json' };
-import fr from '../i18n/fr.json' with { type: 'json' };
-import it from '../i18n/it.json' with { type: 'json' };
 
-/**
- * Loader for translations used in ngx-translate library.
- */
+export type TranslationLoaderFn = () => Promise<{ default: Record<string, string> }>;
+
+// Only 'en' is bundled in the lib. Additional languages must be added by the consuming app
+// via a subclass that overrides `coreTranslationLoaders`. Dynamic import paths with template
+// literals (e.g. `import(\`../${lang}.json\`)`) are not statically analysable by esbuild and
+// are therefore rejected at build time — each language must be an explicit import thunk.
+export const CORE_TRANSLATION_LOADERS: Record<string, TranslationLoaderFn> = {
+  en: () => import('../i18n/en.json'),
+};
+
 @Injectable()
 export class CoreTranslateLoader implements TranslateLoader {
-  // prefix: string;
-  // suffix: string;
-  // enforceLoading: boolean;
-  // useHttpBackend: boolean;
-
   protected coreConfigService: CoreConfigService = inject(CoreConfigService);
   protected http: HttpClient = inject(HttpClient);
 
-  // translations
-  private translations: Record<string, Record<string, string>> = {};
+  // Explicit map so the bundler can statically analyse import paths.
+  // Override in subclasses to add or replace languages.
+  protected coreTranslationLoaders: Record<string, TranslationLoaderFn> = { ...CORE_TRANSLATION_LOADERS };
 
-  // locale translations
-  // with angular<9 assets are not available for libraries
-  // See: https://angular.io/guide/creating-libraries#managing-assets-in-a-library
-  private coreTranslations: Record<string, Record<string, string>> = { de, en, fr, it };
+  private translations: Record<string, Record<string, string>> = {};
 
   /**
    * Return observable used by ngx-translate to get translations.
    * @param lang - string, language to retrieve translations from.
    */
   getTranslation(lang: string): Observable<TranslationObject> {
-    // Already in cache
     if (this.translations[lang] != null) {
       return of(this.translations[lang]);
     }
 
     const urls: string[] = this.coreConfigService.translationsURLs;
 
-    // create the list of http requests
-    const observers = urls.map((url) => {
-      const langURL = url.replace('${lang}', lang);
-      return this.http.get<Record<string, string>>(langURL).pipe(
-        catchError(() => {
-          console.log(`ERROR: Cannot load translation: ${langURL}`);
-          return of({});
-        }),
-      );
-    });
-    // Get local and backend translations
-    return forkJoin(observers).pipe(
-      map((translations) => {
-        // copy local translations
-        if (this.coreTranslations[lang] != null) {
-          this.translations[lang] = { ...this.coreTranslations[lang] };
-        } else {
-          this.translations[lang] = {};
-        }
-        // get remote translations
-        translations.forEach((trans) => {
-          this.translations[lang] = {
-            ...this.translations[lang],
-            ...trans,
-          };
-        });
-        return this.translations[lang];
-      }),
+    const coreTranslation$ = this.coreTranslationLoaders[lang]
+      ? from(this.coreTranslationLoaders[lang]()).pipe(
+          map((m) => m.default),
+          catchError(() => of({} as Record<string, string>)),
+        )
+      : of({} as Record<string, string>);
+
+    const remote$ = urls.length
+      ? forkJoin(
+          urls.map((url) => {
+            const langURL = url.replace('${lang}', lang);
+            return this.http.get<Record<string, string>>(langURL).pipe(
+              catchError(() => {
+                console.log(`ERROR: Cannot load translation: ${langURL}`);
+                return of({} as Record<string, string>);
+              }),
+            );
+          }),
+        )
+      : of([] as Record<string, string>[]);
+
+    return coreTranslation$.pipe(
+      switchMap((core) =>
+        remote$.pipe(
+          map((remotes) => {
+            this.translations[lang] = Object.assign({}, core, ...remotes);
+            return this.translations[lang];
+          }),
+        ),
+      ),
     );
   }
 }

--- a/projects/rero/ng-core/src/lib/translate/pipe/date-translate/date-translate-pipe.spec.ts
+++ b/projects/rero/ng-core/src/lib/translate/pipe/date-translate/date-translate-pipe.spec.ts
@@ -1,21 +1,44 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
+import { registerLocaleData } from '@angular/common';
+import localeDe from '@angular/common/locales/de';
+import localeFr from '@angular/common/locales/fr';
+import localeIt from '@angular/common/locales/it';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { de as primeDe } from 'primelocale/js/de.js';
+import { fr as primeFr } from 'primelocale/js/fr.js';
+import { it as primeIt } from 'primelocale/js/it.js';
+import { CORE_LOCALES, Locales, NgCoreTranslateService } from '../../service/translate/translate-service';
 import { DateTranslatePipe } from './date-translate-pipe';
-import { NgCoreTranslateService } from '../../service/translate/translate-service';
+
+class TestTranslateService extends NgCoreTranslateService {
+  override locales: Locales = {
+    ...CORE_LOCALES,
+    de: { angular: localeDe, primeng: primeDe },
+    fr: { angular: localeFr, primeng: primeFr },
+    it: { angular: localeIt, primeng: primeIt },
+  };
+}
 
 describe('DateTranslatePipePipe', () => {
   let pipe: DateTranslatePipe;
   let service: NgCoreTranslateService;
 
   beforeEach(() => {
+    registerLocaleData(localeDe, 'de');
+    registerLocaleData(localeFr, 'fr');
+    registerLocaleData(localeIt, 'it');
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
-      providers: [DateTranslatePipe],
+      providers: [
+        DateTranslatePipe,
+        { provide: NgCoreTranslateService, useClass: TestTranslateService },
+      ],
     });
     service = TestBed.inject(NgCoreTranslateService);
     pipe = TestBed.inject(DateTranslatePipe);
+    service.use('en');
   });
 
   it('should return the english translation of the date (default)', () => {

--- a/projects/rero/ng-core/src/lib/translate/pipe/translate-language/translate-language.pipe.spec.ts
+++ b/projects/rero/ng-core/src/lib/translate/pipe/translate-language/translate-language.pipe.spec.ts
@@ -1,32 +1,102 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { TranslateLanguagePipe } from './translate-language.pipe';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { TranslateLanguageService } from '../../service/translate-language/translate-language.service';
+import { TranslateLanguagePipe } from './translate-language.pipe';
 
 class TranslateLanguageServiceMock {
-  translate(langCode: string) {
-    return langCode + '-translate';
+  private _currentLang = 'en';
+  readonly languagesVersion = signal(0);
+
+  setCurrentLang(lang: string) { this._currentLang = lang; }
+
+  translate(langCode: string, language?: string) {
+    const lang = language ?? this._currentLang;
+    return `${langCode}-${lang}-v${this.languagesVersion()}`;
   }
 }
 
+@Component({
+  selector: 'ng-core-test-host',
+  template: `<span>{{ langCode | translateLanguage }}</span>`,
+  imports: [TranslateLanguagePipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestHostComponent {
+  langCode = 'fre';
+}
+
+@Component({
+  selector: 'ng-core-test-host-explicit',
+  template: `<span>{{ langCode | translateLanguage : lang }}</span>`,
+  imports: [TranslateLanguagePipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestHostExplicitComponent {
+  langCode = 'fre';
+  lang = 'fr';
+}
+
 describe('TranslateLanguagePipe', () => {
-  let pipe: TranslateLanguagePipe;
+  let translateService: TranslateService;
+  let languageServiceMock: TranslateLanguageServiceMock;
 
   beforeEach(() => {
+    languageServiceMock = new TranslateLanguageServiceMock();
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
-      providers: [TranslateLanguagePipe, { provide: TranslateLanguageService, useClass: TranslateLanguageServiceMock }],
+      providers: [
+        { provide: TranslateLanguageService, useValue: languageServiceMock },
+      ],
     });
-    pipe = TestBed.inject(TranslateLanguagePipe);
+    translateService = TestBed.inject(TranslateService);
+    translateService.setDefaultLang('en');
   });
 
-  it('create an instance', () => {
-    expect(pipe).toBeTruthy();
+  it('should create an instance', () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should transform language code to human language', () => {
-    expect(pipe.transform('fre')).toEqual('fre-translate');
+  it('should transform language code using current language', () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    const span = fixture.nativeElement.querySelector('span');
+    expect(span.textContent.trim()).toBe('fre-en-v0');
+  });
+
+  it('should transform language code using explicit language', () => {
+    const fixture = TestBed.createComponent(TestHostExplicitComponent);
+    fixture.detectChanges();
+    const span = fixture.nativeElement.querySelector('span');
+    expect(span.textContent.trim()).toBe('fre-fr-v0');
+  });
+
+  it('should re-render when language changes via translateService', async () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('span').textContent.trim()).toBe('fre-en-v0');
+
+    languageServiceMock.setCurrentLang('fr');
+    translateService.use('fr');
+    await new Promise(resolve => setTimeout(resolve, 0));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('span').textContent.trim()).toBe('fre-fr-v0');
+  });
+
+  it('should re-render when languagesVersion signal changes', async () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('span').textContent.trim()).toBe('fre-en-v0');
+
+    languageServiceMock.languagesVersion.update(v => v + 1);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('span').textContent.trim()).toBe('fre-en-v1');
   });
 });

--- a/projects/rero/ng-core/src/lib/translate/pipe/translate-language/translate-language.pipe.ts
+++ b/projects/rero/ng-core/src/lib/translate/pipe/translate-language/translate-language.pipe.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { inject, Pipe, PipeTransform } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateLanguageService } from '../../service/translate-language/translate-language.service';
 
 @Pipe({
@@ -9,6 +11,7 @@ import { TranslateLanguageService } from '../../service/translate-language/trans
 })
 export class TranslateLanguagePipe implements PipeTransform {
   protected translateLanguage: TranslateLanguageService = inject(TranslateLanguageService);
+  private currentLang = toSignal(inject(TranslateService).onLangChange);
 
   /**
    * transform language code to human language
@@ -16,6 +19,11 @@ export class TranslateLanguagePipe implements PipeTransform {
    * @param language - ISO 639-1 (2 characters)
    */
   transform(langCode: string, language?: string): string {
+    // pure: false already re-evaluates transform() on every change detection
+    // cycle; reading these signals here is enough to pick up language changes,
+    // no manual markForCheck() needed.
+    this.currentLang();
+    this.translateLanguage.languagesVersion();
     return this.translateLanguage.translate(langCode, language);
   }
 }

--- a/projects/rero/ng-core/src/lib/translate/service/translate-language/translate-language.service.spec.ts
+++ b/projects/rero/ng-core/src/lib/translate/service/translate-language/translate-language.service.spec.ts
@@ -10,7 +10,7 @@ describe('TranslateLanguageService', () => {
     getCurrentLang: vi.fn(),
     onLangChange: of(null),
   };
-  translateServiceSpy.getCurrentLang.mockReturnValue('fr');
+  translateServiceSpy.getCurrentLang.mockReturnValue('en');
 
   let service: TranslateLanguageService;
 
@@ -26,11 +26,19 @@ describe('TranslateLanguageService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should translate language code hat to human language french', () => {
-    expect(service.translate('hat')).toBe('créole haïtien');
+  it('should translate language code to english', () => {
+    expect(service.translate('hat')).toBe('Haitian French Creole');
   });
 
-  it('should translate language code hat to human language english', () => {
-    expect(service.translate('hat', 'en')).toBe('Haitian French Creole');
+  it('should fallback to english when language is not available', () => {
+    expect(service.translate('hat', 'fr')).toBe('Haitian French Creole');
+  });
+
+  it('should return the code when langCode does not exist in any language', () => {
+    expect(service.translate('xxx')).toBe('xxx');
+  });
+
+  it('should return the code when langCode does not exist and language is not available', () => {
+    expect(service.translate('xxx', 'fr')).toBe('xxx');
   });
 });

--- a/projects/rero/ng-core/src/lib/translate/service/translate-language/translate-language.service.ts
+++ b/projects/rero/ng-core/src/lib/translate/service/translate-language/translate-language.service.ts
@@ -1,39 +1,47 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import de from '../../languages/de.json';
 import en from '../../languages/en.json';
-import fr from '../../languages/fr.json';
-import it from '../../languages/it.json';
+
+export type LanguageMap = Record<string, Record<string, string>>;
+export type LanguageLoaderFn = () => Promise<Record<string, string>>;
+
+export const CORE_LANGUAGE_LOADERS: LanguageMap = { en };
 
 @Injectable({
   providedIn: 'root',
 })
 export class TranslateLanguageService {
-  protected translateService: TranslateService = inject(TranslateService);
+  protected translateService = inject(TranslateService);
 
-  // List of preferred languages
-  static PREFERRED_LANGUAGES = ['eng', 'fre', 'ger', 'ita'];
+  protected availableLanguages: LanguageMap = { ...CORE_LANGUAGE_LOADERS };
 
-  // Available languages (import)
-  private _availableLanguages: Record<string, Record<string, string>> = { de, en, fr, it };
+  readonly languagesVersion = signal(0);
 
   /**
    * @param langCode - ISO 639-2 (3 characters)
    * @param language - ISO 639-1 (2 characters)
    * @return human language - string
    */
+  async loadLanguages(loaders: Record<string, LanguageLoaderFn>): Promise<void> {
+    const entries = await Promise.all(
+      Object.entries(loaders).map(async ([lang, loader]) => [lang, await loader()] as [string, Record<string, string>]),
+    );
+    for (const [lang, data] of entries) {
+      this.availableLanguages[lang] = data;
+    }
+    this.languagesVersion.update(v => v + 1);
+  }
+
   translate(langCode: string, language?: string) {
     const lang = language || this.translateService.getCurrentLang();
-    if (!(lang in this._availableLanguages)) {
+    const map = this.availableLanguages[lang] ?? this.availableLanguages['en'];
+
+    if (!map || !(langCode in map)) {
       return langCode;
     }
 
-    if (!(langCode in this._availableLanguages[lang])) {
-      return langCode;
-    }
-
-    return this._availableLanguages[lang][langCode];
+    return map[langCode];
   }
 }

--- a/projects/rero/ng-core/src/lib/translate/service/translate/translate-service.spec.ts
+++ b/projects/rero/ng-core/src/lib/translate/service/translate/translate-service.spec.ts
@@ -23,9 +23,14 @@ describe('NgCoreTranslateService', () => {
     expect(primeConfig.translation.today).toEqual('Today');
   });
 
-  it('should have changed the local service', () => {
-    service.use('fr');
-    expect(primeConfig.translation.today).toEqual("Aujourd'hui");
+  it('should set luxon locale and primeng translation on use()', () => {
+    service.use('en');
+    expect(primeConfig.translation.today).toEqual('Today');
+    expect(Settings.defaultLocale).toEqual('en');
+  });
+
+  it('should not throw when using a language not in locales', () => {
+    expect(() => service.use('fr')).not.toThrow();
     expect(Settings.defaultLocale).toEqual('fr');
   });
 });

--- a/projects/rero/ng-core/src/lib/translate/service/translate/translate-service.ts
+++ b/projects/rero/ng-core/src/lib/translate/service/translate/translate-service.ts
@@ -1,29 +1,31 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { registerLocaleData } from '@angular/common';
-import localeDe from '@angular/common/locales/de';
 import localeEn from '@angular/common/locales/en-GB';
-import localeFr from '@angular/common/locales/fr';
-import localeIt from '@angular/common/locales/it';
 import { inject, Injectable } from '@angular/core';
 import { InterpolatableTranslationObject, TranslateService } from '@ngx-translate/core';
 import { Settings } from 'luxon';
-import { de } from 'primelocale/js/de.js';
 import { en } from 'primelocale/js/en.js';
-import { fr } from 'primelocale/js/fr.js';
-import { it } from 'primelocale/js/it.js';
+import { Translation } from 'primeng/api';
 import { PrimeNG } from 'primeng/config';
 import { Observable } from 'rxjs';
 import { CoreConfigService } from '../../../core/service/core-config/core-config.service';
-import { Translation } from 'primeng/api';
 
-type Locales = Record<
+export type Locales = Record<
   string,
   {
     angular: unknown;
     primeng: Translation;
   }
 >;
+
+// Only 'en' is bundled in the lib. Angular locale data and PrimeNG translations cannot be
+// loaded via HTTP — they are compiled JS modules that must be statically imported and registered
+// via registerLocaleData(). Consuming apps must extend NgCoreTranslateService and override
+// `locales` to add their required languages.
+export const CORE_LOCALES: Locales = {
+  en: { angular: localeEn, primeng: en },
+};
 
 @Injectable({
   providedIn: 'root',
@@ -32,30 +34,17 @@ export class NgCoreTranslateService extends TranslateService {
   protected primeNG: PrimeNG = inject(PrimeNG);
   protected coreConfigService: CoreConfigService = inject(CoreConfigService);
 
-  private locales: Locales = {
-    de: { angular: localeDe, primeng: de },
-    en: { angular: localeEn, primeng: en },
-    fr: { angular: localeFr, primeng: fr },
-    it: { angular: localeIt, primeng: it },
-  };
+  protected locales: Locales = { ...CORE_LOCALES };
 
   constructor() {
     super();
-    for (const [key, value] of Object.entries(this.locales)) {
-      registerLocaleData(value.angular, key);
-    }
-    const languages: string[] = this.coreConfigService.languages;
-    super.addLangs(languages);
-
     super.setFallbackLang(this.coreConfigService.defaultLanguage);
-    if (!super.getCurrentLang()) {
-      super.use(this.coreConfigService.defaultLanguage);
-    }
   }
 
   use(lang: string): Observable<InterpolatableTranslationObject> {
     Settings.defaultLocale = lang;
     if (this.locales[lang]) {
+      registerLocaleData(this.locales[lang].angular, lang);
       this.primeNG.setTranslation(this.locales[lang].primeng);
     }
     return super.use(lang);

--- a/projects/rero/ng-core/tsconfig.lib.json
+++ b/projects/rero/ng-core/tsconfig.lib.json
@@ -9,8 +9,8 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "preserveSymlinks": true,
-    "enableResourceInlining": true
+    "preserveSymlinks": true
   },
+  "include": ["src/**/*.ts", "src/**/*.json"],
   "exclude": ["src/test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Only 'en' is bundled in the lib for translations (CoreTranslateLoader),
locale data (NgCoreTranslateService) and language name maps
(TranslateLanguageService). Consuming apps override the respective
protected maps to add their required languages.

Dynamic HTTP loading is not used for locale data and language name maps
because Angular locale modules and PrimeNG translations are compiled JS
modules that must be statically imported — esbuild rejects dynamic import
paths with template literals at build time.

ng-core-tester demonstrates the pattern with AppTranslateLoader,
AppTranslateService and AppTranslateLanguageService adding de/fr/it, and
AppInitializerService resolving available languages from a fake user API.

- Add `languagesVersion` signal to TranslateLanguageService; incremented
  after each loadLanguages() call so dependants can react without polling
- Fix TranslateLanguagePipe to re-execute on language change in zoneless
  mode: toSignal(onLangChange) + effect(languagesVersion → markForCheck)
  with pure:false; signals alone are insufficient outside reactive contexts
- Use fetch() factory in AppTranslateLanguageService to load ng-core
  language name JSON files from /assets/ng-core/languages/ at runtime
- Rewrite httpPendingInterceptor as export function (Angular 21 style)
- Fix date-translate-pipe.spec: call service.use('en') in beforeEach so
  getCurrentLang() returns 'en' (en-GB path) rather than falling back to
  the test runner LOCALE_ID (en-US)
- Fix translate-language.pipe.spec: migrate to host component pattern
  (TestBed.createComponent) to provide the view context required by
  ChangeDetectorRef and effect(); add languagesVersion signal to mock