### PR TITLE
fix(editor): autofocus template select after async load

### DIFF
--- a/projects/rero/ng-core/src/lib/formly/types/select/select.component.ts
+++ b/projects/rero/ng-core/src/lib/formly/types/select/select.component.ts
@@ -25,6 +25,7 @@ import { TranslateLabelService } from '../../service/translate-label.service';
 
 export interface ISelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
   appendTo?: any;
+  autofocus?: boolean;
   class: string;
   dropdownIcon?: string;
   editable: boolean;
@@ -67,6 +68,7 @@ export interface IFormlySelectFieldConfig extends FormlyFieldConfig<ISelectProps
     @if (props.options) {
       <p-select
         [appendTo]="props.appendTo"
+        [autofocus]="props.autofocus"
         [class]="props.class"
         [dropdownIcon]="props.dropdownIcon"
         [editable]="props.editable"
@@ -129,6 +131,7 @@ export class SelectComponent extends FieldType<FieldTypeConfig<ISelectProps>> im
   /** Default properties */
   defaultOptions: Partial<FieldTypeConfig<ISelectProps>> = {
     props: {
+      autofocus: false,
       disabled: false,
       editable: false,
       filterMatchMode: 'contains',

--- a/projects/rero/ng-core/src/lib/record/editor/component/editor/editor.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/component/editor/editor.component.ts
@@ -603,7 +603,7 @@ export class EditorComponent<TMetadata extends JsonObject = JsonObject>
   showLoadTemplateDialog(): void {
     this.dialogService.open(LoadTemplateFormComponent, {
       header: this.translateService.instant('Load from template'),
-      focusOnShow: true,
+      focusOnShow: false,
       width: '50vw',
       position: 'top',
       modal: true,

--- a/projects/rero/ng-core/src/lib/record/editor/component/load-template-form/load-template-form.component.ts
+++ b/projects/rero/ng-core/src/lib/record/editor/component/load-template-form/load-template-form.component.ts
@@ -51,6 +51,7 @@ export class LoadTemplateFormComponent implements OnInit {
       type: 'select',
       props: {
         appendTo: 'body',
+        autofocus: true,
         required: true,
         group: true,
         filter: true,


### PR DESCRIPTION
The template dialog relied on the dialog's one-time focusOnShow, which fires before the select exists in the DOM. Locally the response is fast enough that focus sometimes lands; in production the network latency makes it always miss.

* expose an `autofocus` prop on the formly select type
* enable it on the load-template field so the select focuses itself once rendered
* set focusOnShow back to false to avoid focusing the wrong element

Closes rero/rero-ils#4057.