### PR TITLE
fix(utils): harden removeChars default char set

### DIFF
--- a/projects/rero/ng-core/src/lib/core/utils/utils.spec.ts
+++ b/projects/rero/ng-core/src/lib/core/utils/utils.spec.ts
@@ -39,4 +39,17 @@ describe('Utils', () => {
     expect(removeChars('"House"')).toEqual('House');
     expect(removeChars('"House Philipp\'s"', ["'"])).toEqual('"House Philipps"');
   });
+
+  it('should remove parentheses and backslashes by default', () => {
+    expect(removeChars('foo (bar) baz')).toEqual('foo bar baz');
+    expect(removeChars('foo\\bar')).toEqual('foobar');
+  });
+
+  it('should keep other Elasticsearch operators untouched by default', () => {
+    expect(removeChars('title:foo AND +bar -baz*')).toEqual('title:foo AND +bar -baz*');
+  });
+
+  it('should treat a custom hyphen as a literal char, not a range', () => {
+    expect(removeChars('abcxyz-', ['a', '-', 'z'])).toEqual('bcxy');
+  });
 });

--- a/projects/rero/ng-core/src/lib/core/utils/utils.ts
+++ b/projects/rero/ng-core/src/lib/core/utils/utils.ts
@@ -34,7 +34,8 @@ export function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-export function removeChars(value: string, chars: string[] = ['"']): string {
-  const re = new RegExp('[' + chars.join('') + ']', 'gi');
+export function removeChars(value: string, chars: string[] = ['"', '(', ')', '\\']): string {
+  const escaped = chars.map((char) => char.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&'));
+  const re = new RegExp('[' + escaped.join('') + ']', 'gi');
   return value.replace(re, '');
 }


### PR DESCRIPTION
* Add "(", ")" and "\" to the default removed chars, since they can break the query string structure built around user input
* Escape each char before building the RegExp, since "\" was previously unsafe to pass in
* Keep other ES/Lucene operators (:, +, -, *) untouched by default