### PR TITLE
fix(aggregations): update content of the intitial closed aggs.

### DIFF
--- a/projects/rero/ng-core/src/lib/record/component/search/store/features/with-aggregations.feature.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/features/with-aggregations.feature.spec.ts
@@ -582,6 +582,47 @@ describe('withAggregations feature', () => {
       const aggs = store.aggregations();
       expect(aggs[0].loaded).toBe(true);
       expect(aggs[0].value.buckets.length).toBe(1);
+      // Expanding a facet marks it as included for subsequent searches.
+      expect((aggs[0] as any).included).toBe(true);
+    });
+  });
+
+  describe('included state on enrichment', () => {
+    it('should keep a closed facet not included when enriched from esResult', async () => {
+      store.updateRouteConfig({
+        types: [
+          {
+            key: 'documents',
+            label: 'Documents',
+            aggregationsOrder: ['author'],
+            sortOptions: [],
+          } as any,
+        ],
+      });
+      store.setCurrentType('documents');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // `author` is not expanded/hidden: it starts as not included.
+      expect((store.aggregations().find((a) => a.key === 'author') as any).included).toBe(false);
+
+      // Elasticsearch returns the aggregation (e.g. because a filter requested it).
+      store.setResults({
+        hits: { hits: [], total: { value: 0, relation: 'eq' } },
+        aggregations: {
+          author: {
+            buckets: [{ key: 'Smith', doc_count: 10 }],
+            doc_count: 10,
+            type: 'terms',
+          },
+        } as any,
+        links: { self: '' },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const enriched = store.aggregations().find((a) => a.key === 'author');
+      // Enrichment must not force inclusion of a closed facet.
+      expect(enriched!.loaded).toBe(true);
+      expect((enriched as any).included).toBe(false);
     });
   });
 });

--- a/projects/rero/ng-core/src/lib/record/component/search/store/features/with-aggregations.feature.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/features/with-aggregations.feature.ts
@@ -104,9 +104,11 @@ export function withAggregations() {
       },
 
       setAggregationExpanded(key: string, expanded: boolean): void {
-        const aggregations = store.aggregations().map((agg) =>
-          agg.key === key ? { ...agg, expanded } : agg,
-        );
+        const aggregations = store.aggregations().map((agg) => {
+          if (agg.key !== key) return agg;
+          if (expanded) return { ...agg, expanded };
+          return { ...agg, expanded, loaded: false, value: { ...agg.value, buckets: [] } };
+        });
         patchState(store, { aggregations });
       },
 
@@ -171,6 +173,11 @@ export function withAggregations() {
           type: esAggregation.type || aggregation.type || 'terms',
           config: esAggregation.config || aggregation.config,
           name: aggregation.name || esAggregation.name,
+          // Preserve the existing `included` state (spread from `aggregation`).
+          // Enrichment must not force inclusion: `setAggregations` enriches every
+          // aggregation returned by Elasticsearch, including closed facets that were
+          // only requested because they have an active filter. Inclusion is set
+          // explicitly by `fetchAggregationBuckets` when the user expands a facet.
           value: {
             ...aggregation.value,
             buckets: esAggregation.buckets || aggregation.value.buckets,
@@ -234,7 +241,9 @@ export function withAggregations() {
                   const currentAggregations = store.aggregations();
                   const updatedAggregations = currentAggregations.map(agg => {
                     if (agg.key === params.aggregationKey) {
-                      return store.enrichAggregation(agg, esResult.aggregations[params.aggregationKey]);
+                      // The user explicitly expanded this facet: mark it as included so
+                      // it is requested in subsequent searches.
+                      return { ...store.enrichAggregation(agg, esResult.aggregations[params.aggregationKey]), included: true };
                     }
                     return agg;
                   });


### PR DESCRIPTION
fix(aggregations): clear buckets and reset loaded state on collapse

Mark an aggregation as included only when the user explicitly expands it
(via fetchAggregationBuckets), so it is requested in the next fetchRecords
call. Enrichment no longer forces `included: true`: `setAggregations`
enriches every aggregation returned by Elasticsearch, including closed
facets requested only because they carry an active filter, and must
preserve their existing `included` state instead of overwriting it.

* Closes rero/rero-ils#4177.

Co-Authored-By: Johnny Mariéthoz <johnny.mariethoz@rero.ch>
Co-Authored-By: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>
