### PR TITLE
fix(search): apply persistent filter default from url

### DIFF
--- a/projects/rero/ng-core/src/lib/record/component/search/record-search/record-search.component.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/record-search/record-search.component.ts
@@ -22,13 +22,12 @@ import { Message } from 'primeng/message';
 import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { ErrorComponent, SearchInputComponent, UpperCaseFirstPipe } from '../../../../core';
-import { Aggregations, SearchFilter } from '../../../../model';
+import { Aggregations } from '../../../../model';
 import { ActionStatus } from '../../../../model/action-status.interface';
 import { ExportFormat } from '../../../model/record-search.interface';
 import { ApiService } from '../../../service/api/api.service';
 import { RecordUiService } from '../../../service/record-ui/record-ui.service';
 import { RecordService } from '../../../service/record/record.service';
-import { AggregationsFilter } from '../model/aggregations-filter.interface';
 import { RecordSearchStore } from '../store/record-search.store';
 import { RecordSearchAggregationComponent } from './aggregation/aggregation.component';
 import { ListFiltersComponent } from './aggregation/list-filters/list-filters.component';
@@ -265,42 +264,6 @@ export class RecordSearchComponent {
    */
   aggregations$(aggregations: Aggregations): Observable<Aggregations> {
     return of(aggregations);
-  }
-
-  /**
-   * Extract persistent search filters on current url
-   * @return Array of aggregations filter
-   */
-  protected _extractPersistentAggregationsFilters(): AggregationsFilter[] {
-    const persistent: AggregationsFilter[] = [];
-    this._flatSearchFilters()
-      .filter((filter) => filter.persistent === true)
-      .forEach((filter: SearchFilter) => {
-        if (Object.hasOwn(this.activatedRoute.snapshot.queryParams, filter.filter)) {
-          const data = this.activatedRoute.snapshot.queryParams[filter.filter];
-          persistent.push({
-            key: filter.filter,
-            values: Array.isArray(data) ? data : [data],
-          });
-        }
-      });
-    return persistent;
-  }
-
-  /**
-   * Make all search filters on same array level
-   * @returns - A filters array
-   */
-  protected _flatSearchFilters(): SearchFilter[] {
-    const flatFilters: SearchFilter[] = [];
-    this.store.config().searchFilters.forEach((searchFilter: any) => {
-      if (searchFilter.filters) {
-        searchFilter.filters.forEach((filter: any) => flatFilters.push(filter));
-      } else {
-        flatFilters.push(searchFilter);
-      }
-    });
-    return flatFilters;
   }
 
   scrollToTop(): void {

--- a/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.spec.ts
@@ -669,6 +669,88 @@ describe('RecordSearchStore', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(store.hasFilter('status', 'published')).toBe(false);
     });
+
+    it('should apply the disabledValue of a persistent filter when it is missing from the url', async () => {
+      store.updateRouteConfig({
+        types: [
+          {
+            key: 'documents',
+            label: 'Documents',
+            searchFilters: [
+              { filter: 'simple', label: 'Expert search', value: '0', disabledValue: '1', persistent: true },
+            ],
+            sortOptions: [],
+          } as any,
+        ],
+      });
+      store.updateCurrentType('documents');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(store.hasFilter('simple', '1')).toBe(true);
+    });
+
+    it('should not override a persistent filter value coming from the url', async () => {
+      store.updateRouteConfig({
+        types: [
+          {
+            key: 'documents',
+            label: 'Documents',
+            searchFilters: [
+              { filter: 'simple', label: 'Expert search', value: '0', disabledValue: '1', persistent: true },
+            ],
+            sortOptions: [],
+          } as any,
+        ],
+      });
+      // Simulate the value being set from the URL query params before filters init.
+      store.updateAggregationsFilter('simple', ['0']);
+      store.updateCurrentType('documents');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(store.hasFilter('simple', '0')).toBe(true);
+      expect(store.hasFilter('simple', '1')).toBe(false);
+    });
+
+    it('should not apply a default for a non-persistent filter', async () => {
+      store.updateRouteConfig({
+        types: [
+          {
+            key: 'documents',
+            label: 'Documents',
+            searchFilters: [{ filter: 'online', label: 'Online', value: 'true', disabledValue: 'false' }],
+            sortOptions: [],
+          } as any,
+        ],
+      });
+      store.updateCurrentType('documents');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(store.hasFilter('online', 'false')).toBe(false);
+    });
+
+    it('should apply the disabledValue of a persistent filter nested in a section', async () => {
+      store.updateRouteConfig({
+        types: [
+          {
+            key: 'documents',
+            label: 'Documents',
+            searchFilters: [
+              {
+                label: 'Search options',
+                filters: [
+                  { filter: 'simple', label: 'Expert search', value: '0', disabledValue: '1', persistent: true },
+                ],
+              },
+            ],
+            sortOptions: [],
+          } as any,
+        ],
+      });
+      store.updateCurrentType('documents');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(store.hasFilter('simple', '1')).toBe(true);
+    });
   });
 
   describe('processBuckets()', () => {

--- a/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.ts
@@ -7,11 +7,25 @@ import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { _, TranslateService } from '@ngx-translate/core';
 import { filter, pipe, tap } from 'rxjs';
 import { RecordType } from '../../../model';
+import { SearchFilter, SearchFilterSection } from '../../../../model';
 import { shallowEqual } from '../../../record-search-utils';
 import { withAggregations } from './features/with-aggregations.feature';
 import { withConfig } from './features/with-config.feature';
 import { FetchRecordsParams, withResults } from './features/with-results.feature';
 import { withSearchParams } from './features/with-search-params.feature';
+
+/** Flatten search filters, extracting the filters nested inside sections. */
+function flatSearchFilters(searchFilters: (SearchFilter | SearchFilterSection)[]): SearchFilter[] {
+  const flat: SearchFilter[] = [];
+  (searchFilters ?? []).forEach((item) => {
+    if ('filters' in item) {
+      flat.push(...item.filters);
+    } else {
+      flat.push(item);
+    }
+  });
+  return flat;
+}
 
 /**
  * RecordSearchStore - SignalStore for managing record search state
@@ -73,6 +87,21 @@ export const RecordSearchStore = signalStore(
           if (!shallowEqual(filters, store.searchFilters())) {
             store.updateSearchFilters(filters);
           }
+          // Apply the default value of persistent filters when they are missing from the URL.
+          // For a persistent filter, `disabledValue` is the implicit default, so the search
+          // behaves the same whatever the entry point (menu, shortcut, direct URL). Without
+          // this, opening a search page with no query params would drop e.g. `simple=1` and
+          // silently switch to expert search.
+          flatSearchFilters(filters).forEach((f: SearchFilter) => {
+            const defaultValue = f.disabledValue;
+            if (f.persistent !== true || defaultValue == null) {
+              return;
+            }
+            // Only apply the default when the filter is not already set from the URL.
+            if (!store.aggregationsFilters().some((a) => a.key === f.filter)) {
+              store.updateAggregationsFilter(f.filter, [defaultValue]);
+            }
+          });
         }),
       ),
     ),


### PR DESCRIPTION
Persistent search filters expose `disabledValue` as their implicit default. When a search page was opened with no query params, that default was dropped, so e.g. `simple=1` was lost and the UI silently switched to expert search.

Seed the `disabledValue` of persistent filters on init when they are absent from the aggregations filters, without overriding a value already coming from the url.

Remove the orphaned `_extractPersistentAggregationsFilters()` from the search component, which handled this on the url before the signal store migration and is now superseded by the store logic.

Closes rero/rero-ils#4184.