### PR TITLE
ci: use pnpm ci instead of pnpm install --frozen-lockfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Enable Corepack
       run: corepack enable
     - name: install package
-      run: pnpm install --frozen-lockfile
+      run: pnpm ci
     - name: run tests
       run: pnpm exec ./run-tests.sh
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Build CSS
         run: pnpm run build-css

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Run semantic-release
         id: release


### PR DESCRIPTION
pnpm ci is the dedicated CI/CD install command: it runs a clean install with a frozen lockfile, equivalent to npm ci for pnpm.