### PR TITLE
fix(formly): fix select overlay scroll-dismiss and touch scroll on iOS

### DIFF
--- a/projects/rero/ng-core/src/lib/formly/types/multi-select/multi-select.component.ts
+++ b/projects/rero/ng-core/src/lib/formly/types/multi-select/multi-select.component.ts
@@ -17,9 +17,11 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FieldType, FieldTypeConfig, FormlyFieldConfig, FormlyFieldProps, FormlyModule } from '@ngx-formly/core';
 import { FormlyFieldSelectProps, FormlySelectOption } from '@ngx-formly/core/select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { OverlayOptions } from 'primeng/api';
 import { MultiSelect } from 'primeng/multiselect';
 import { combineLatest, map, Observable, of, startWith } from 'rxjs';
 import { CONFIG } from '../../../core/config/config';
+import { fixOverlayTouchScroll } from '../../utils/overlay-scroll-fix';
 import { TranslateLabelService } from '../../service/translate-label.service';
 
 export interface NgCoreMultiSelectOption extends FormlySelectOption {
@@ -38,6 +40,7 @@ export interface IMultiSelectProps extends FormlyFieldProps, FormlyFieldSelectPr
   fluid: boolean;
   group: boolean;
   loadingIcon?: string;
+  overlayOptions?: OverlayOptions;
   panelStyleClass?: string;
   placeholder?: string;
   required: boolean;
@@ -74,6 +77,7 @@ export interface FormlyMultiSelectFieldConfig extends FormlyFieldConfig<IMultiSe
       [formlyAttributes]="field"
       [group]="props.group"
       [loadingIcon]="props.loadingIcon"
+      [overlayOptions]="props.overlayOptions"
       [ngClass]="{ 'ng-invalid ng-dirty': showError }"
       [options]="optionValues()"
       optionLabel="label"
@@ -89,6 +93,7 @@ export interface FormlyMultiSelectFieldConfig extends FormlyFieldConfig<IMultiSe
       [tooltipStyleClass]="props.tooltipStyleClass"
       (onChange)="props.change && props.change(field, $event)"
       (onClear)="clearValidators()"
+      (onPanelShow)="onOverlayShow()"
     >
       <ng-template #selectedItems let-items>
         @for (option of items; track option.value; let last = $last) {
@@ -139,6 +144,16 @@ export class MultiSelectComponent extends FieldType<FieldTypeConfig<IMultiSelect
       fluid: true,
       class: '',
       group: false,
+      // Don't dismiss the overlay on ancestor scroll: PrimeNG binds a scroll
+      // listener on every scrollable ancestor of the trigger (e.g. an
+      // enclosing accordion) and closes the overlay when one of them fires.
+      // On iOS Safari this fires while touch-scrolling the option list
+      // itself, closing the overlay before the user can scroll it.
+      // Other dismissal types (outside click, resize, escape) still use
+      // PrimeNG's own validity check.
+      overlayOptions: {
+        listener: (_event, options) => (options?.type === 'scroll' ? false : (options?.valid ?? true)),
+      },
       placeholder: 'Select…',
       emptyFilterMessage: '',
       emptyMessage: '',
@@ -200,5 +215,9 @@ export class MultiSelectComponent extends FieldType<FieldTypeConfig<IMultiSelect
   clearValidators() {
     const { errors } = this.formControl;
     this.formControl.setErrors(errors?.required ? { required: true } : null);
+  }
+
+  onOverlayShow(): void {
+    fixOverlayTouchScroll('.p-multiselect-overlay');
   }
 }

--- a/projects/rero/ng-core/src/lib/formly/types/select/select.component.ts
+++ b/projects/rero/ng-core/src/lib/formly/types/select/select.component.ts
@@ -20,9 +20,11 @@ import { FieldType, FieldTypeConfig, FormlyFieldConfig, FormlyModule } from '@ng
 import { FormlyFieldSelectProps } from '@ngx-formly/core/select';
 import { FormlyFieldProps } from '@ngx-formly/primeng/form-field';
 import { _, TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { OverlayOptions } from 'primeng/api';
 import { Select } from 'primeng/select';
 import { combineLatest, map, Observable, of, startWith } from 'rxjs';
 import { CONFIG } from '../../../core/config/config';
+import { fixOverlayTouchScroll } from '../../utils/overlay-scroll-fix';
 import { TranslateLabelService } from '../../service/translate-label.service';
 
 export interface ISelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
@@ -37,6 +39,7 @@ export interface ISelectProps extends FormlyFieldProps, FormlyFieldSelectProps {
   fluid: boolean;
   group: boolean;
   loadingIcon?: string;
+  overlayOptions?: OverlayOptions;
   panelStyleClass?: string;
   placeholder?: string;
   required: boolean;
@@ -84,6 +87,7 @@ export interface IFormlySelectFieldConfig extends FormlyFieldConfig<ISelectProps
         [formlyAttributes]="field"
         [group]="props.group"
         [loadingIcon]="props.loadingIcon"
+        [overlayOptions]="props.overlayOptions"
         [scrollHeight]="props.scrollHeight"
         [ngClass]="{ 'ng-invalid ng-dirty': showError }"
         [options]="optionValues()"
@@ -100,6 +104,7 @@ export interface IFormlySelectFieldConfig extends FormlyFieldConfig<ISelectProps
         [tooltipStyleClass]="props.tooltipStyleClass"
         (onChange)="props.change && props.change(field, $event)"
         (onClear)="clearValidators()"
+        (onShow)="onOverlayShow()"
       >
         <ng-template let-selected #selectedItem>
           {{ selected.untranslatedLabel | translate }}
@@ -149,6 +154,16 @@ export class SelectComponent extends FieldType<FieldTypeConfig<ISelectProps>> im
       items: [],
       class: '',
       group: false,
+      // Don't dismiss the overlay on ancestor scroll: PrimeNG binds a scroll
+      // listener on every scrollable ancestor of the trigger (e.g. an
+      // enclosing accordion) and closes the overlay when one of them fires.
+      // On iOS Safari this fires while touch-scrolling the option list
+      // itself, closing the overlay before the user can scroll it.
+      // Other dismissal types (outside click, resize, escape) still use
+      // PrimeNG's own validity check.
+      overlayOptions: {
+        listener: (_event, options) => (options?.type === 'scroll' ? false : (options?.valid ?? true)),
+      },
       placeholder: _('Select…'),
       required: false,
       scrollHeight: CONFIG.DEFAULT_SELECT_SCROLL_HEIGHT,
@@ -223,5 +238,9 @@ export class SelectComponent extends FieldType<FieldTypeConfig<ISelectProps>> im
   clearValidators() {
     const { errors } = this.formControl;
     this.formControl.setErrors(errors?.required ? { required: true } : null);
+  }
+
+  onOverlayShow(): void {
+    fixOverlayTouchScroll('.p-select-overlay');
   }
 }

--- a/projects/rero/ng-core/src/lib/formly/types/tree-select/tree-select.component.ts
+++ b/projects/rero/ng-core/src/lib/formly/types/tree-select/tree-select.component.ts
@@ -7,11 +7,12 @@ import { FormsModule } from '@angular/forms';
 import { FieldType, FieldTypeConfig, FormlyFieldProps, FormlyModule } from '@ngx-formly/core';
 import { FormlySelectOption } from '@ngx-formly/core/select';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { TreeNode } from 'primeng/api';
+import { OverlayOptions, TreeNode } from 'primeng/api';
 import { TreeNodeSelectEvent } from 'primeng/tree';
 import { TreeSelect } from 'primeng/treeselect';
 import { combineLatest, map, of, startWith, tap } from 'rxjs';
 import { CONFIG } from '../../../core/config/config';
+import { fixOverlayTouchScroll } from '../../utils/overlay-scroll-fix';
 import { TranslateLabelService } from '../../service/translate-label.service';
 
 export interface NgCoreTreeSelectOption extends FormlySelectOption {
@@ -28,6 +29,7 @@ export interface ITreeSelectProps extends FormlyFieldProps {
   filterInputAutoFocus: boolean;
   filterPlaceholder?: string;
   fluid: boolean;
+  overlayOptions?: OverlayOptions;
   panelClass: string;
   panelStyleClass: string;
   placeholder: string;
@@ -51,6 +53,7 @@ export interface ITreeSelectProps extends FormlyFieldProps {
       [formlyAttributes]="field"
       [ngModel]="nodeSelected()"
       [options]="optionValues()"
+      [overlayOptions]="props.overlayOptions"
       [panelClass]="props.panelClass"
       [panelStyleClass]="props.panelStyleClass"
       [placeholder]="props.placeholder | translate"
@@ -60,6 +63,7 @@ export interface ITreeSelectProps extends FormlyFieldProps {
       (onNodeSelect)="setFormValue($event)"
       (onNodeUnselect)="clearFormValue()"
       (onClear)="clearFormValue()"
+      (onShow)="onOverlayShow()"
     >
       <ng-template let-item #item>
         <span class="core:whitespace-normal">
@@ -87,6 +91,16 @@ export class TreeSelectComponent extends FieldType<FieldTypeConfig<ITreeSelectPr
       fluid: true,
       class: '',
       containerStyleClass: '',
+      // Don't dismiss the overlay on ancestor scroll: PrimeNG binds a scroll
+      // listener on every scrollable ancestor of the trigger (e.g. an
+      // enclosing accordion) and closes the overlay when one of them fires.
+      // On iOS Safari this fires while touch-scrolling the option list
+      // itself, closing the overlay before the user can scroll it.
+      // Other dismissal types (outside click, resize, escape) still use
+      // PrimeNG's own validity check.
+      overlayOptions: {
+        listener: (_event, options) => (options?.type === 'scroll' ? false : (options?.valid ?? true)),
+      },
       panelClass: '',
       panelStyleClass: '',
       placeholder: 'Select…',
@@ -168,5 +182,9 @@ export class TreeSelectComponent extends FieldType<FieldTypeConfig<ITreeSelectPr
     }
 
     return data ?? null;
+  }
+
+  onOverlayShow(): void {
+    fixOverlayTouchScroll('.p-treeselect-overlay');
   }
 }

--- a/projects/rero/ng-core/src/lib/formly/utils/overlay-scroll-fix.spec.ts
+++ b/projects/rero/ng-core/src/lib/formly/utils/overlay-scroll-fix.spec.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { isIOSDevice } from './overlay-scroll-fix';
+
+describe('isIOSDevice', () => {
+  const stubNavigator = (overrides: Partial<Navigator>): void => {
+    vi.stubGlobal('navigator', { ...navigator, ...overrides });
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should return false on a desktop Mac (no touch support)', () => {
+    stubNavigator({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    });
+    expect(isIOSDevice()).toBe(false);
+  });
+
+  it('should return true on an iPhone', () => {
+    stubNavigator({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+    });
+    expect(isIOSDevice()).toBe(true);
+  });
+
+  it('should return true on an iPad reporting itself as MacIntel with touch support', () => {
+    stubNavigator({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+    });
+    expect(isIOSDevice()).toBe(true);
+  });
+
+  it('should return false on a non-Apple platform', () => {
+    stubNavigator({
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      platform: 'Win32',
+      maxTouchPoints: 0,
+    });
+    expect(isIOSDevice()).toBe(false);
+  });
+});

--- a/projects/rero/ng-core/src/lib/formly/utils/overlay-scroll-fix.ts
+++ b/projects/rero/ng-core/src/lib/formly/utils/overlay-scroll-fix.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * True on iOS/iPadOS WebKit, including iPadOS which reports `navigator.platform`
+ * as "MacIntel" for compatibility (on every Mac, Intel or Apple Silicon alike)
+ * but, unlike a real Mac, exposes touch support.
+ */
+export function isIOSDevice(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1))
+  );
+}
+
+/**
+ * Works around a touch-scroll bug affecting p-select/p-multiSelect/p-treeSelect
+ * overlay panels on iOS Safari.
+ *
+ * When the overlay opens, WebKit appears to build its internal scroll tree
+ * for the option list container using stale (pre-animation) dimensions -
+ * likely because `p-motion` animates the overlay open from a near-zero
+ * height. The result: the option list's `overflow: auto` never receives
+ * touch-scroll gestures (its `scrollTop` never changes), and the gesture is
+ * instead routed to the page, which visually drags the still-open overlay
+ * along with it. This reproduces on iOS Simulator and on physical iPhones,
+ * with or without `appendTo="body"`, and independently of any dismiss
+ * listener or body-scroll-locking technique.
+ *
+ * Confirmed fix: detaching and reattaching the overlay element in the DOM
+ * (`element.parentElement.appendChild(element)`) forces WebKit to rebuild
+ * its scroll tree with the overlay's final dimensions, after which native
+ * touch-scroll works correctly. This does not change the element's position
+ * in the DOM tree, but re-parenting can drop focus from a focused descendant
+ * (e.g. the filter input), so focus is restored afterwards.
+ *
+ * Must run after the `p-motion` open animation has settled - calling it
+ * synchronously from the overlay's `(onShow)` event is too early and has no
+ * effect (WebKit hasn't built its (defective) scroll tree yet), hence the
+ * delay.
+ *
+ * Only applied on iOS: other platforms don't exhibit this bug, and the
+ * re-parenting has a visible cost (reflow, transient focus loss) that isn't
+ * worth paying elsewhere.
+ */
+export function fixOverlayTouchScroll(overlaySelector: string): void {
+  if (!isIOSDevice()) {
+    return;
+  }
+  setTimeout(() => {
+    const overlay = document.querySelector(overlaySelector);
+    if (!overlay?.parentElement) {
+      return;
+    }
+    const { activeElement } = document;
+    const hadFocus = overlay.contains(activeElement);
+    overlay.parentElement.appendChild(overlay);
+    if (hadFocus && activeElement instanceof HTMLElement) {
+      activeElement.focus();
+    }
+  }, 100);
+}


### PR DESCRIPTION
* PrimeNG's p-select/p-multiSelect/p-treeSelect bind a scroll listener on every scrollable ancestor of the trigger element and close the overlay as soon as one of them fires a scroll event, even when appendTo="body" moves the overlay itself to <body>
* On iOS Safari, touch-scrolling the option list fires a scroll event on an ancestor (e.g. an enclosing accordion, or the page itself) before the list has actually scrolled, closing the overlay immediately - the user sees the page behind it move instead of the option list, and can never reach entries further down
* Default overlayOptions to a listener that ignores scroll-based dismissal, exposed as an overridable prop on all three field types
* Compromise: an overlay is no longer auto-closed when the page scrolls behind it while open; since PrimeNG only repositions the overlay once on open (not continuously on scroll), it can end up visually detached from its trigger in that case. This only matters if the user manages to scroll the page while the overlay is open, which most existing usages already prevent