### PR TITLE
feat(filters): add button to remove all filters

### DIFF
--- a/projects/rero/ng-core/src/lib/record/component/search/record-search/aggregation/list-filters/list-filters.component.html
+++ b/projects/rero/ng-core/src/lib/record/component/search/record-search/aggregation/list-filters/list-filters.component.html
@@ -15,5 +15,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         (onClick)="removeFilter(filter)"
       />
     }
+    <div class="core:flex core:w-full core:justify-start core:lg:w-auto core:lg:justify-end core:lg:ml-auto">
+      <p-button
+        class="core:mb-2"
+        icon="fa-solid fa-xmark"
+        [outlined]="true"
+        severity="secondary"
+        [title]="'Remove all filters' | translate"
+        [aria-label]="'Remove all filters' | translate"
+        (onClick)="store.clearFilters()"
+      />
+    </div>
   </div>
 }

--- a/projects/rero/ng-core/src/lib/record/component/search/record-search/aggregation/list-filters/list-filters.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/record-search/aggregation/list-filters/list-filters.component.spec.ts
@@ -42,9 +42,9 @@ describe('ListFiltersComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display 4 buttons', () => {
+  it('should display 5 buttons', () => {
     const buttons = fixture.debugElement.nativeElement.querySelectorAll('p-button');
-    expect(buttons.length).toBe(4);
+    expect(buttons.length).toBe(5);
   });
 
   it('should have the button label translated', () => {


### PR DESCRIPTION
Users can now clear every active filter at once instead of removing them one by one.