### PR TITLE
feat(formly): export overlay touch-scroll iOS fix

### DIFF
--- a/projects/rero/ng-core/src/lib/formly/index.ts
+++ b/projects/rero/ng-core/src/lib/formly/index.ts
@@ -21,6 +21,7 @@ export * from './types/remote-autocomplete/remote-autocomplete.service';
 export * from './types/remote-autocomplete/remote-autocomplete.interface';
 export * from './types/remote-autocomplete/remote-autocomplete.component';
 export * from './types/select/select.component';
+export * from './utils/overlay-scroll-fix';
 export * from './service/translate-label.service';
 export * from './validator/email.validator';
 export * from './config/formly-config';


### PR DESCRIPTION
Expose fixOverlayTouchScroll and isIOSDevice from the public API so consumers using p-select/p-multiSelect/p-treeSelect directly (outside formly) can apply the same iOS Safari touch-scroll workaround.