### PR TITLE
fix(search): apply the configured default sort

### DIFF
--- a/projects/rero/ng-core/src/lib/record/component/search/record-search-page.component.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/record-search-page.component.spec.ts
@@ -3,9 +3,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
+import { RecordType } from '../../model';
 import { RecordUiService } from '../../service/record-ui/record-ui.service';
 import { RecordService } from '../../service/record/record.service';
 import { RecordSearchPageComponent } from './record-search-page.component';
+import { DEFAULT_RECORD_TYPE } from './store/features/with-config.feature';
 import { RecordSearchStore } from './store/record-search.store';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
@@ -21,6 +23,16 @@ describe('RecordSearchPageComponent', () => {
   let queryParamMapSubject: BehaviorSubject<ParamMap>;
   let paramMapSubject: BehaviorSubject<ParamMap>;
   let mockActivatedRoute: any;
+
+  const documentsTypeWithSortOptions: RecordType = {
+    ...DEFAULT_RECORD_TYPE,
+    key: 'documents',
+    label: 'Documents',
+    sortOptions: [
+      { label: 'Relevance', value: 'relevance', defaultQuery: true },
+      { label: 'Date descending', value: 'newest', defaultNoQuery: true },
+    ],
+  };
 
   // No logs needed for tests
 
@@ -303,6 +315,54 @@ describe('RecordSearchPageComponent', () => {
           replaceUrl: true,
         }),
       );
+    });
+
+    it('should materialize the default sort of the configuration in the URL', async () => {
+      mockRouter.navigate.mockClear();
+      component.store.updateRouteConfig({ types: [documentsTypeWithSortOptions] });
+
+      await vi.waitFor(() =>
+        expect(mockRouter.navigate).toHaveBeenLastCalledWith(
+          expect.any(Array),
+          expect.objectContaining({
+            queryParams: expect.objectContaining({ sort: 'newest' }),
+          }),
+        ),
+      );
+    });
+
+    it('should materialize the default sort of a query in the URL', async () => {
+      component.store.updateRouteConfig({ types: [documentsTypeWithSortOptions] });
+
+      // Wait for the configuration default sort to reach the URL before switching to a query
+      await vi.waitFor(() =>
+        expect(mockRouter.navigate).toHaveBeenLastCalledWith(
+          expect.any(Array),
+          expect.objectContaining({
+            queryParams: expect.objectContaining({ sort: 'newest' }),
+          }),
+        ),
+      );
+      mockRouter.navigate.mockClear();
+      component.store.updateQuery('test search');
+
+      await vi.waitFor(() =>
+        expect(mockRouter.navigate).toHaveBeenLastCalledWith(
+          expect.any(Array),
+          expect.objectContaining({
+            queryParams: expect.objectContaining({ sort: 'relevance' }),
+          }),
+        ),
+      );
+    });
+
+    it('should not add an empty sort parameter in the URL without sort options', async () => {
+      mockRouter.navigate.mockClear();
+      component.store.updatePage(2);
+
+      await vi.waitFor(() => expect(mockRouter.navigate).toHaveBeenCalled());
+      const { queryParams } = mockRouter.navigate.mock.calls.at(-1)[1];
+      expect(queryParams.sort).toBeUndefined();
     });
   });
 

--- a/projects/rero/ng-core/src/lib/record/component/search/record-search-page.component.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/record-search-page.component.ts
@@ -54,13 +54,19 @@ export class RecordSearchPageComponent {
     effect(() => {
       const currentType = this.store.currentType();
       // Read individual signals so the effect tracks only the URL-relevant fields
+      // `activeSort` is used instead of `sort`, so the default sort defined in the
+      // configuration is materialized in the URL instead of an empty `sort` parameter.
+      const activeSort = this.store.activeSort();
       const storeParams: Partial<SearchParams> = {
         q: this.store.q(),
         page: this.store.page(),
         size: this.store.size(),
-        sort: this.store.sort(),
         aggregationsFilters: this.store.aggregationsFilters(),
       };
+      // No sort option is available for this type: keep the parameter out of the URL.
+      if (activeSort) {
+        storeParams.sort = activeSort;
+      }
 
       // We use untracked to read current route state without creating dependencies,
       // preventing recursive effect triggers.
@@ -72,7 +78,7 @@ export class RecordSearchPageComponent {
         const typeInSync = currentType === currentTypeInUrl;
 
         if (!paramsInSync || !typeInSync) {
-          this.navigate(currentType, storeParams as SearchParams);
+          this.navigate(currentType, storeParams);
         }
       });
     });
@@ -81,7 +87,7 @@ export class RecordSearchPageComponent {
   /**
    * Helper method to perform the actual router navigation
    */
-  private navigate(currentType: string, params: SearchParams) {
+  private navigate(currentType: string, params: Partial<SearchParams>) {
     this.router.navigate(['..', currentType], {
       relativeTo: this.route,
       queryParams: searchParamsToUrlParams(params, this.store.aggregationsFilters()),

--- a/projects/rero/ng-core/src/lib/record/component/search/store/features/with-aggregations.feature.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/features/with-aggregations.feature.ts
@@ -44,7 +44,6 @@ export function withAggregations() {
     {
       state: type<{
         aggregationsFilters: AggregationsFilter[];
-        sort: string;
         q: string;
         esResult: EsResult | null;
         currentType: string;
@@ -53,6 +52,7 @@ export function withAggregations() {
         config: Signal<RecordType>;
         currentIndex: Signal<string>;
         aggregationsExpand: Signal<string[]>;
+        activeSort: Signal<string>;
         recordService: RecordService;
       }>(),
       methods: type<{
@@ -207,7 +207,7 @@ export function withAggregations() {
             const aggregations = store.aggregations();
             const aggregationsFilters = store.aggregationsFilters();
             const config = store.config();
-            const sort = store.sort();
+            const sort = store.activeSort();
             const currentIndex = store.currentIndex();
             const query = store.q();
 

--- a/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.spec.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.spec.ts
@@ -630,6 +630,17 @@ describe('RecordSearchStore', () => {
       expect(store.activeSort()).toBe('best');
     });
 
+    it('should fetch records with the default sort when no sort is selected', async () => {
+      store.updateCurrentType('documents');
+
+      await vi.waitFor(() =>
+        expect(mockRecordService.getRecords).toHaveBeenCalledWith(
+          'documents',
+          expect.objectContaining({ sort: 'newest' }),
+        ),
+      );
+    });
+
     it('should apply defaultSearchInputFilters when no query', async () => {
       store.updateRouteConfig({
         types: [

--- a/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.ts
+++ b/projects/rero/ng-core/src/lib/record/component/search/store/record-search.store.ts
@@ -126,7 +126,7 @@ export const RecordSearchStore = signalStore(
             itemsPerPage: store.size(),
             aggregationsFilters: store.aggregationsFilters(),
             preFilters: config.preFilters,
-            sort: store.sort(),
+            sort: store.activeSort(),
             facets: store.facetsParameter(),
             headers: config.listHeaders,
           };

--- a/projects/rero/ng-core/src/lib/record/record-search-utils.ts
+++ b/projects/rero/ng-core/src/lib/record/record-search-utils.ts
@@ -64,7 +64,7 @@ export function paramMapToSearchParams(map: ParamMap): Partial<SearchParams> {
 }
 
 export function searchParamsToUrlParams(
-  params: SearchParams,
+  params: Partial<SearchParams>,
   aggregationsFilters: AggregationsFilter[],
 ): Record<string, unknown> {
   const urlParams: Record<string, unknown> = stripUndefined({


### PR DESCRIPTION
The store keeps `sort` empty until the user picks an option, but the URL sync, the record fetch and the lazy facet fetch all read that raw state instead of `activeSort`, which resolves `defaultQuery` / `defaultNoQuery` from the configuration.

* materialize `activeSort` in the URL, so a brief view opens on `sort=newest` instead of an empty `sort=` parameter, as it did before the signal store migration. The parameter is omitted when the type declares no sort option
* send `activeSort` with the search request: the sort was left to the backend default, which is not defined for every index, so a brief view could be ordered by score while the sort menu announced another option
* use the same sort for the lazy aggregation buckets request